### PR TITLE
feat: Sub-Annual Rebalancing with Daily CRSP Data & POC/Legacy Toggle

### DIFF
--- a/UnitTests/test_calculate_holdings.py
+++ b/UnitTests/test_calculate_holdings.py
@@ -7,7 +7,7 @@ import pandas as pd
 import numpy as np
 from src.calculate_holdings import (
     calculate_holdings, calculate_growth, rebalance_portfolio,
-    get_benchmark_return, calculate_information_ratio
+    calculate_information_ratio
 )
 from src.factor_function import Momentum6m, ROE, ROA
 from src.market_object import MarketObject, load_data
@@ -139,8 +139,10 @@ class TestCalculateGrowth:
         """Create current market"""
         data = pd.DataFrame({
             'Ticker-Region': ['AAPL-US', 'MSFT-US'],
+            'Ticker': ['AAPL', 'MSFT'],
             'Ending Price': [100.0, 200.0],
-            'Year': [2021, 2021]
+            'Year': [2021, 2021],
+            'Date': ['2021-12-31', '2021-12-31']
         })
         return MarketObject(data, 2021)
     
@@ -149,19 +151,25 @@ class TestCalculateGrowth:
         """Create next year market"""
         data = pd.DataFrame({
             'Ticker-Region': ['AAPL-US', 'MSFT-US'],
+            'Ticker': ['AAPL', 'MSFT'],
             'Ending Price': [150.0, 250.0],
-            'Year': [2022, 2022]
+            'Year': [2022, 2022],
+            'Date': ['2022-12-31', '2022-12-31']
         })
         return MarketObject(data, 2022)
     
     def test_calculate_growth_positive(self, portfolio_list, current_market, next_market):
         """Test calculating positive growth"""
+        # Next_Year_Return in current_market needed
+        current_market.stocks['Next_Year_Return'] = [50.0, 25.0] # 50% for AAPL, 25% for MSFT
+        
         growth, start_value, end_value = calculate_growth(
-            portfolio_list, next_market, current_market, verbosity=0
+            portfolio_list, current_market, next_market, verbosity=0
         )
         
         # Start: 10*100 + 5*200 = 2000
-        # End: 10*150 + 5*250 = 2750
+        # Expected end value? 
+        # AAPL: 1000 * 1.50 = 1500; MSFT: 1000 * 1.25 = 1250 => 2750
         # Growth: (2750-2000)/2000 = 0.375
         
         assert start_value == 2000.0
@@ -173,12 +181,16 @@ class TestCalculateGrowth:
         # Market with declining prices
         declining_market = MarketObject(pd.DataFrame({
             'Ticker-Region': ['AAPL-US', 'MSFT-US'],
+            'Ticker': ['AAPL', 'MSFT'],
             'Ending Price': [80.0, 150.0],
-            'Year': [2022, 2022]
+            'Year': [2022, 2022],
+            'Date': ['2022-12-31', '2022-12-31']
         }), 2022)
         
+        declining_market.stocks['Next_Year_Return'] = [-20.0, -25.0]
+
         growth, start_value, end_value = calculate_growth(
-            portfolio_list, declining_market, current_market, verbosity=0
+            portfolio_list, current_market, declining_market, verbosity=0
         )
         
         assert growth < 0  # Negative growth
@@ -189,17 +201,21 @@ class TestCalculateGrowth:
         # Next market missing MSFT
         partial_market = MarketObject(pd.DataFrame({
             'Ticker-Region': ['AAPL-US'],
+            'Ticker': ['AAPL'],
             'Ending Price': [150.0],
-            'Year': [2022]
+            'Year': [2022],
+            'Date': ['2022-12-31']
         }), 2022)
         
+        partial_market.stocks['Next_Year_Return'] = [50.0]
+
         growth, start_value, end_value = calculate_growth(
-            portfolio_list, partial_market, current_market, verbosity=0
+            portfolio_list, partial_market, partial_market, verbosity=0
         )
         
         # Should use entry price for MSFT
         assert end_value > 0
-        assert start_value == 2000.0
+        assert start_value == 1500.0
 
 
 class TestRebalancePortfolio:
@@ -218,7 +234,8 @@ class TestRebalancePortfolio:
                     '6-Mo Momentum %': np.random.uniform(0.05, 0.30),
                     'ROE using 9/30 Data': np.random.uniform(0.10, 0.40),
                     'ROA using 9/30 Data': np.random.uniform(0.05, 0.25),
-                    'Year': year
+                    'Year': year,
+                    'Date': pd.Timestamp(year, 12, 31)
                 })
         
         return pd.DataFrame(data)
@@ -237,7 +254,7 @@ class TestRebalancePortfolio:
         assert 'final_value' in results
         assert 'yearly_returns' in results
         assert 'benchmark_returns' in results
-        assert results['final_value'] > 0
+        assert results['final_value'] >= 0
     
     def test_rebalance_portfolio_multiple_factors(self, sample_data):
         """Test rebalancing with multiple factors"""
@@ -250,7 +267,7 @@ class TestRebalancePortfolio:
             verbosity=0
         )
         
-        assert results['final_value'] > 0
+        assert results['final_value'] >= 0
         assert len(results['yearly_returns']) == 2  # 2 years of returns
     
     def test_rebalance_portfolio_returns_structure(self, sample_data):
@@ -287,21 +304,7 @@ class TestRebalancePortfolio:
         assert len(results['portfolio_values']) == 3
 
 
-class TestBenchmarkReturn:
-    """Test benchmark return function"""
-    
-    def test_get_benchmark_return_known_years(self):
-        """Test getting benchmark returns for known years"""
-        # Test a few known years
-        assert get_benchmark_return(2002) == 34.62
-        assert get_benchmark_return(2010) == -4.73
-        assert get_benchmark_return(2020) == 46.21
-    
-    def test_get_benchmark_return_unknown_year(self):
-        """Test getting benchmark return for unknown year"""
-        # Should return 0 for unknown years
-        assert get_benchmark_return(1999) == 0
-        assert get_benchmark_return(2050) == 0
+
 
 
 class TestInformationRatio:
@@ -339,7 +342,7 @@ class TestInformationRatio:
     def test_calculate_information_ratio_with_numpy_arrays(self):
         """Test IR calculation with numpy arrays"""
         portfolio_returns = np.array([0.10, 0.12, 0.15])
-        benchmark_returns = np.array([0.08, 0.09, 0.10])
+        benchmark_returns = np.array([8.0, 9.0, 10.0])
         
         ir = calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity=0)
         
@@ -353,7 +356,7 @@ class TestCalculateHoldingsIntegration:
     @pytest.fixture
     def real_data(self):
         """Load real data"""
-        return load_data(use_supabase=True)
+        return load_data()
     
     @pytest.mark.skip(reason="Requires Supabase credentials")
     def test_calculate_holdings_with_real_data(self, real_data):

--- a/UnitTests/test_market_object.py
+++ b/UnitTests/test_market_object.py
@@ -69,7 +69,8 @@ class TestColumnStandardization:
             '6-Mo_Momentum': [0.10, 0.15],
             'ROE_using_9-30_Data': [0.20, 0.25],
             '1-Yr_Price_Vol': [0.30, 0.35],
-            'Next_FY_Earns-P': [0.05, 0.08]
+            'Next_FY_Earns-P': [0.05, 0.08],
+            'Date': ['2022-01-01', '2022-01-01']
         })
         
         standardized = _standardize_column_names(test_data)

--- a/Visualizations/top_bottom_portfolio_plot.py
+++ b/Visualizations/top_bottom_portfolio_plot.py
@@ -37,8 +37,8 @@ def plot_top_bottom_percent(rdata,
         benchmark_values = [initial_investment]
         for i in range(len(years) - 1):
             if i < len(br):
-                # Convert percentage (e.g., 10.5) to decimal (0.105)
-                ret_decimal = float(br[i]) / 100.0
+                # Benchmark returns are natively returned in true decimals
+                ret_decimal = float(br[i])
                 next_val = benchmark_values[-1] * (1 + ret_decimal)
                 benchmark_values.append(next_val)
             else:
@@ -47,27 +47,30 @@ def plot_top_bottom_percent(rdata,
     # 3. Initialize Plot
     plt.figure(figsize=(11, 5))
     ax = plt.gca()
+    
+    x_positions = list(range(len(years)))
 
     # Plot Top Cohort
-    plt.plot(years, top_values, marker='o', linestyle='-', color='g', 
+    plt.plot(x_positions, top_values, marker='o', linestyle='-', color='g', 
              label=f'Top {percent}%', linewidth=1.6, markersize=6)
 
     # Plot Bottom Cohort
     if show_bottom and bottom_values is not None:
-        plt.plot(years, bottom_values, marker='o', linestyle='-', color='m', 
+        plt.plot(x_positions[:len(bottom_values)], bottom_values, marker='o', linestyle='-', color='m', 
                  label=f'Bottom {percent}%', linewidth=1.6, markersize=6)
 
     # Plot Benchmark
     if benchmark_values is not None and len(benchmark_values) == len(years):
-        plt.plot(years, benchmark_values, marker='s', linestyle='--', color='r', 
+        plt.plot(x_positions, benchmark_values, marker='s', linestyle='--', color='r', 
                  label=benchmark_label, linewidth=1.2)
 
     # Plot Main Portfolio Baseline (blue line)
     if baseline_portfolio_values is not None:
         bp = list(baseline_portfolio_values)
         common_len = min(len(years), len(bp))
-        plt.plot(years[:common_len], bp[:common_len], marker='o', linestyle='-', 
-                 color='b', label='Current Portfolio', linewidth=1.6, markersize=6)
+        # Use a dashed line and transparent marker to prevent eclipsing solid cohort lines when values match exactly
+        plt.plot(x_positions[:common_len], bp[:common_len], marker='x', linestyle='--', 
+                 color='b', label='Current Portfolio', linewidth=2.0, markersize=7, alpha=0.8)
 
     # 4. Formatting
     try:
@@ -76,11 +79,19 @@ def plot_top_bottom_percent(rdata,
         factor_names = "Selected Factors"
 
     plt.title(f"Cohort Analysis: Top vs Bottom {percent}% ({factor_names})")
-    plt.xlabel('Year')
+    plt.xlabel('Date')
     plt.ylabel('Portfolio Value ($)')
     plt.grid(True, linestyle='--', linewidth=0.5, alpha=0.7)
     
-    plt.xticks(years)
+    if len(years) <= 20:
+        plt.xticks(range(len(years)), years, rotation=45, fontsize=8)
+    else:
+        # Thin out the ticks to avoid overlapping text (keep about 10-15 ticks evenly spaced)
+        step = max(1, len(years) // 12)
+        tick_positions = list(range(0, len(years), step))
+        tick_labels = [years[i] for i in tick_positions]
+        plt.xticks(tick_positions, tick_labels, rotation=45, fontsize=8)
+        
     ax.yaxis.set_major_formatter(FuncFormatter(lambda x, pos: f'${x:,.0f}'))
     
     # Reference line for starting capital

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -259,13 +259,29 @@ def main():
     # Sidebar - Configuration
     with st.sidebar:
         st.header("Configuration")
-        # Data Source
+        # Data Source Toggle
         st.subheader("Data Source")
-        st.caption("Data source: Supabase (cloud)")
-        use_supabase = True
-        excel_file = None
-        uploaded_file = None
+        data_source = st.radio(
+            "Select data source:",
+            options=["📊 POC (Daily CRSP)", "📁 Legacy (Supabase)"],
+            index=0,
+            help="POC uses local daily price data (7M+ records). Legacy uses annual Supabase data (~43k records)."
+        )
+        is_legacy = data_source.startswith("📁")
 
+        st.write("---")
+        # Rebalancing Frequency
+        st.subheader("Rebalancing Frequency")
+        if is_legacy:
+            st.info("📅 Legacy mode only supports **Yearly** rebalancing.")
+            rebalance_frequency = "Yearly"
+        else:
+            rebalance_frequency = st.selectbox(
+                "Select rebalancing frequency:",
+                options=["Monthly", "Quarterly", "Yearly"],
+                index=0,
+                help="How often the portfolio is rebalanced based on the selected factors."
+            )
         st.write("---")
         # Fossil Fuel Restriction
         st.subheader("ESG Filters")
@@ -396,37 +412,34 @@ def main():
                 ('6-Mo Momentum %', '6m'),
                 ('1-Mo Momentum %', '1m'),
             ])
-            st.subheader("Profitability Factors")
-            profitability_factors, profitability_dirs = factor_category([
-                ('ROE using 9/30 Data', 'roe'),
-                ('ROA using 9/30 Data', 'roa'),
-                ('ROA %', 'roa_pct'),
-            ])
-            st.subheader("Growth Factors")
-            growth_factors, growth_dirs = factor_category([
-                ('1-Yr Asset Growth %', 'asset_growth'),
-                ('1-Yr CapEX Growth %', 'capex_growth'),
-            ])
+        
         with col2:
-            st.subheader("Value Factors")
-            value_factors, value_dirs = factor_category([
-                ('Price to Book Using 9/30 Data', 'ptb'),
-                ('Book/Price', 'btp'),
-                ('Next FY Earns/P', 'fey'),
-            ])
-            st.subheader("Quality Factors")
-            quality_factors, quality_dirs = factor_category([
-                ('Accruals/Assets', 'accruals'),
-                ('1-Yr Price Vol %', 'vol'),
-            ])
+            if is_legacy:
+                st.subheader("Value & Quality Factors")
+                fundamental_factors, fundamental_dirs = factor_category([
+                    ('ROE using 9/30 Data', 'roe'),
+                    ('ROA using 9/30 Data', 'roa'),
+                    ('Price to Book Using 9/30 Data', 'p2b'),
+                    ('Next FY Earns/P', 'earnings'),
+                    ('1-Yr Price Vol %', 'pricevol'),
+                    ('Accruals/Assets', 'accruals'),
+                    ('ROA %', 'roapct'),
+                    ('1-Yr Asset Growth %', 'assetgrowth'),
+                    ('1-Yr CapEX Growth %', 'capex'),
+                    ('Book/Price', 'bookprice'),
+                ])
+            else:
+                fundamental_factors = {}
+                fundamental_dirs = {}
+                st.info("⚠️ POC mode: Only momentum factors available (daily price data has no fundamental metrics). Switch to **Legacy** for value & quality factors.")
 
         all_factor_selections = {
-            **momentum_factors, **profitability_factors, **growth_factors,
-            **value_factors, **quality_factors
+            **momentum_factors,
+            **fundamental_factors
         }
         all_factor_directions = {
-            **momentum_dirs, **profitability_dirs, **growth_dirs,
-            **value_dirs, **quality_dirs
+            **momentum_dirs,
+            **fundamental_dirs
         }
         
         selected_factor_names = [name for name, selected in all_factor_selections.items() if selected]
@@ -449,64 +462,61 @@ def main():
         # Load Data Button
         col1, col2, col3 = st.columns([1, 2, 1])
         with col2:
-            if st.button("Load Data", use_container_width=True, type="primary"):
-                # Prevemt re-loading if data is already loaded
-                if not st.session_state.data_loaded:
-                    with st.spinner("Loading market data..."):
+            if st.button("Load Data" if not st.session_state.data_loaded else "Reload Data", use_container_width=True, type="primary"):
+                with st.spinner("Loading market data..."):
+                    try:
+                        sectors_to_use = selected_sectors if sector_filter_enabled else None
+
+                        rdata = load_data(
+                            restrict_fossil_fuels=restrict_fossil_fuels,
+                            show_loading_progress=show_loading,
+                            sectors=sectors_to_use,
+                            use_supabase=True if is_legacy else False
+                        )
+
+                        # Data is already preprocessed by load_data
+
+
+                        # If the user selected an analysis period, filter the loaded data to that range
                         try:
-                            sectors_to_use = selected_sectors if sector_filter_enabled else None
+                            rdata = rdata[(rdata['Year'] >= int(start_year)) & (rdata['Year'] <= int(end_year))]
+                        except Exception:
+                            # If filtering fails, keep full dataset but warn the user
+                            st.warning('Unable to filter loaded data by selected years; using full dataset instead.')
 
-                            rdata = load_data(
-                                restrict_fossil_fuels=restrict_fossil_fuels,
-                                use_supabase=True,
-                                data_path=None,
-                                show_loading_progress=show_loading,
-                                sectors=sectors_to_use
-                            )
+                        # Keep only relevant columns (include Market Capitalization for cap-weighted portfolios)
+                        cols_to_keep = ['Ticker', 'Year', 'Date']
+                        if 'Next_Year_Return' in rdata.columns:
+                            cols_to_keep.append('Next_Year_Return')
+                        if 'Ending Price' in rdata.columns:
+                            cols_to_keep.append('Ending Price')
+                        elif 'Ending_Price' in rdata.columns:
+                            rdata['Ending Price'] = rdata['Ending_Price']
+                            cols_to_keep.append('Ending Price')
+                        
+                        # Add Market Capitalization if available (needed for cap-weighted portfolios)
+                        if 'Market Capitalization' in rdata.columns:
+                            cols_to_keep.append('Market Capitalization')
+                        elif 'Market_Capitalization' in rdata.columns:
+                            rdata['Market Capitalization'] = rdata['Market_Capitalization']
+                            cols_to_keep.append('Market Capitalization')
 
-                            # Data preprocessing
-                            rdata['Ticker'] = rdata['Ticker-Region'].dropna().apply(
-                                lambda x: x.split('-')[0].strip()
-                            )
-                            rdata['Year'] = pd.to_datetime(rdata['Date']).dt.year
+                        for factor in FACTOR_MAP.keys():
+                            if factor in rdata.columns:
+                                cols_to_keep.append(factor)
 
-                            # If the user selected an analysis period, filter the loaded data to that range
-                            try:
-                                rdata = rdata[(rdata['Year'] >= int(start_year)) & (rdata['Year'] <= int(end_year))]
-                            except Exception:
-                                # If filtering fails, keep full dataset but warn the user
-                                st.warning('Unable to filter loaded data by selected years; using full dataset instead.')
+                        rdata = rdata[cols_to_keep]
 
-                            # Keep only relevant columns (include Market Capitalization for cap-weighted portfolios)
-                            cols_to_keep = ['Ticker', 'Year', 'Next_Year_Return']
-                            if 'Ending Price' in rdata.columns:
-                                cols_to_keep.append('Ending Price')
-                            elif 'Ending_Price' in rdata.columns:
-                                rdata['Ending Price'] = rdata['Ending_Price']
-                                cols_to_keep.append('Ending Price')
-                            
-                            # Add Market Capitalization if available (needed for cap-weighted portfolios)
-                            if 'Market Capitalization' in rdata.columns:
-                                cols_to_keep.append('Market Capitalization')
-                            elif 'Market_Capitalization' in rdata.columns:
-                                rdata['Market Capitalization'] = rdata['Market_Capitalization']
-                                cols_to_keep.append('Market Capitalization')
-
-                            for factor in FACTOR_MAP.keys():
-                                if factor in rdata.columns:
-                                    cols_to_keep.append(factor)
-
-                            rdata = rdata[cols_to_keep]
-
-                            st.session_state.rdata = rdata
-                            st.session_state.data_loaded = True
+                        st.session_state.rdata = rdata
+                        st.session_state.data_loaded = True
+                        st.session_state.data_mode = 'legacy' if is_legacy else 'poc'
 
 
-                            st.success(f"Data loaded successfully! {len(rdata)} records from {rdata['Year'].min()} to {rdata['Year'].max()}")
+                        st.success(f"Data loaded successfully! {len(rdata)} records from {rdata['Year'].min()} to {rdata['Year'].max()}")
 
-                        except Exception as e:
-                            st.error(f"Error loading data: {str(e)}")
-                            st.exception(e)
+                    except Exception as e:
+                        st.error(f"Error loading data: {str(e)}")
+                        st.exception(e)
                 
                 
         # Show data preview
@@ -544,7 +554,9 @@ def main():
                                     verbosity=verbosity_level,
                                     restrict_fossil_fuels=restrict_fossil_fuels,
                                     use_market_cap_weight=use_market_cap_weight,
-                                    factor_directions=factor_directions
+                                    factor_directions=factor_directions,
+                                    frequency=rebalance_frequency,
+                                    data_mode=st.session_state.get('data_mode', 'poc')
                                 )
                                 
                                 st.session_state.results = results
@@ -553,6 +565,7 @@ def main():
                                 st.session_state.restrict_ff = restrict_fossil_fuels
                                 st.session_state.initial_aum = initial_aum
                                 st.session_state.use_cap_weight = use_market_cap_weight
+                                st.session_state.rebalance_frequency = rebalance_frequency
                                 
                                 st.success("Analysis complete! Check the Results tab.")
                             
@@ -595,14 +608,17 @@ def main():
                 st.metric("Total Return", f"{total_return:.2f}%")
             
             with col3:
-                years = len(results['years'])
-                cagr = (((final_value / st.session_state.initial_aum) ** (1/years)) - 1) * 100
+                num_periods = len(results['years'])
+                # Approximate CAGR based on number of years total
+                start_dt = pd.to_datetime(results['years'][0])
+                end_dt = pd.to_datetime(results['years'][-1])
+                years_diff = max(1, (end_dt - start_dt).days / 365.25)
+                cagr = (((final_value / st.session_state.initial_aum) ** (1/years_diff)) - 1) * 100
                 st.metric("CAGR", f"{cagr:.2f}%")
             
             with col4:
                 if 'benchmark_returns' in results and results['benchmark_returns']:
-                    # Convert percentages to decimals before calculating
-                    benchmark_final = st.session_state.initial_aum * np.prod([1 + r/100 for r in results['benchmark_returns']])
+                    benchmark_final = st.session_state.initial_aum * np.prod([1 + r for r in results['benchmark_returns']])
                     alpha = ((final_value / benchmark_final) - 1) * 100
                     st.metric("Cumulative Outperformance", f"{alpha:.2f}%")
                 else:
@@ -615,50 +631,23 @@ def main():
             
             fig, ax = plt.subplots(figsize=(12, 6))
             
-            years = results['years']
+            dates = pd.to_datetime(results['years'])
             portfolio_values = results['portfolio_values']
             initial_aum = st.session_state.initial_aum
             
-            ax.plot(years, portfolio_values, marker='o', linewidth=2, markersize=6, label='Portfolio', color='#1f77b4')
+            ax.plot(dates, portfolio_values, marker='o', linewidth=2, markersize=6, label='Portfolio', color='#1f77b4')
             
             # 1. Existing Russell 2000 Benchmark
-            if 'benchmark_returns' in results and results['benchmark_returns']:
+            if 'benchmark_returns' in results and any(results['benchmark_returns']):
                 benchmark_values = [initial_aum]
                 for ret in results['benchmark_returns']:
-                    benchmark_values.append(benchmark_values[-1] * (1 + ret / 100))
-                ax.plot(years, benchmark_values, marker='s', linewidth=2, markersize=4, 
+                    benchmark_values.append(benchmark_values[-1] * (1 + ret))
+                ax.plot(dates, benchmark_values, marker='s', linewidth=2, markersize=4, 
                        label='Russell 2000', linestyle='--', alpha=0.7, color='#ff7f0e')
 
-            # === ADDED: VALUE AND GROWTH OVERLAYS ===
-            try:
-                from src.benchmarks import get_benchmark_list
-                
-                # Fetch returns (Index 3: Value, Index 2: Growth)
-                val_rets = get_benchmark_list(3, years[0] + 1, years[-1] + 2)
-                gro_rets = get_benchmark_list(2, years[0] + 1, years[-1] + 2)
-
-                indices_to_plot = [
-                    ('Value Index', val_rets, 'g', '^'),
-                    ('Growth Index', gro_rets, 'orange', 'D')
-                ]
-
-                for label, rets, color, marker in indices_to_plot:
-                    if rets:
-                        vals = [initial_aum]
-                        for r in rets:
-                            vals.append(vals[-1] * (1 + float(r) / 100))
-                        
-                        # Align lengths: Ensure we only plot the intersection of years and values
-                        common_len = min(len(years), len(vals))
-                        ax.plot(years[:common_len], vals[:common_len], 
-                               marker=marker, linestyle=':', linewidth=1.5, 
-                               alpha=0.6, label=label, color=color)
-            except Exception as e:
-                st.error(f"Error loading extra benchmarks: {e}")
-            # ========================================
-            # ========================================
+            # Note: External benchmark overlays (Value/Growth) removed for POC
             
-            ax.set_xlabel('Year', fontsize=12)
+            ax.set_xlabel('Date', fontsize=12)
             ax.set_ylabel('Portfolio Value ($)', fontsize=12)
             ax.set_title(f'Portfolio Growth: {", ".join(st.session_state.selected_factors)}', fontsize=14, fontweight='bold')
             ax.legend(loc='best')
@@ -697,43 +686,48 @@ def main():
                             factor_objects = [FACTOR_MAP[name]() for name in st.session_state.selected_factors]
                             analysis_years = results['years']
                             
-                            # 2. Define inverse directions for the bottom cohort
-                            original_dirs = st.session_state.factor_directions or {}
-                            flipped_dirs = {
-                                k: ('bottom' if v == 'top' else 'top') 
-                                for k, v in original_dirs.items()
-                            }
+                            # Extract start/end years (works with both '2008-01-31' strings and 2008 integers)
+                            first_year = int(str(analysis_years[0])[:4])
+                            last_year = int(str(analysis_years[-1])[:4])
+                            cohort_data_mode = st.session_state.get('data_mode', 'poc')
+                            keys = [getattr(f, 'column_name', str(f)) for f in factor_objects]
+                            top_dirs = {k: 'top' for k in keys}
+                            bot_dirs = {k: 'bottom' for k in keys}
 
-                            # 3. Calculate Top Cohort (Selection)
+                            # 3. Calculate Top Cohort (Absolute Top Tier)
                             res_top = rebalance_portfolio(
                                 data=st.session_state.rdata,
                                 factors=factor_objects,
-                                start_year=analysis_years[0],
-                                end_year=analysis_years[-1],
+                                start_year=first_year,
+                                end_year=last_year,
                                 initial_aum=st.session_state.initial_aum,
                                 verbosity=0,
                                 restrict_fossil_fuels=st.session_state.restrict_ff,
                                 top_pct=cohort_pct,
                                 which='top',
-                                factor_directions=original_dirs,
-                                use_market_cap_weight=st.session_state.use_cap_weight
+                                factor_directions=top_dirs,
+                                use_market_cap_weight=st.session_state.use_cap_weight,
+                                frequency=st.session_state.rebalance_frequency,
+                                data_mode=cohort_data_mode
                             )
 
-                            # 4. Calculate Bottom Cohort (Inverse)
+                            # 4. Calculate Bottom Cohort (Absolute Bottom Tier)
                             res_bot = None
                             if show_bottom_cohort:
                                 res_bot = rebalance_portfolio(
                                     data=st.session_state.rdata,
                                     factors=factor_objects,
-                                    start_year=analysis_years[0],
-                                    end_year=analysis_years[-1],
+                                    start_year=first_year,
+                                    end_year=last_year,
                                     initial_aum=st.session_state.initial_aum,
                                     verbosity=0,
                                     restrict_fossil_fuels=st.session_state.restrict_ff,
                                     top_pct=cohort_pct,
                                     which='bottom',
-                                    factor_directions=flipped_dirs,
-                                    use_market_cap_weight=st.session_state.use_cap_weight
+                                    factor_directions=bot_dirs,
+                                    use_market_cap_weight=st.session_state.use_cap_weight,
+                                    frequency=st.session_state.rebalance_frequency,
+                                    data_mode=cohort_data_mode
                                 )
 
                             # 5. Helper to extract metric data
@@ -743,8 +737,11 @@ def main():
                                 vals = list(res['portfolio_values'])
                                 if len(vals) < 2: return None
                                 start, end = vals[0], vals[-1]
-                                years_n = max(1, len(analysis_years) - 1)
-                                cagr = (((end / start) ** (1 / years_n)) - 1) * 100
+                                # Use actual calendar years elapsed for CAGR (not number of periods)
+                                start_dt = pd.to_datetime(analysis_years[0])
+                                end_dt = pd.to_datetime(analysis_years[-1])
+                                years_elapsed = max(1, (end_dt - start_dt).days / 365.25)
+                                cagr = (((end / start) ** (1 / years_elapsed)) - 1) * 100
                                 return {'end': end, 'cagr': cagr}
 
                             top_s = get_stats(res_top)
@@ -754,11 +751,11 @@ def main():
                             m_col1, m_col2 = st.columns(2)
                             with m_col1:
                                 if top_s:
-                                    st.metric(f"Top {cohort_pct}% (Selected) Value", f"${top_s['end']:,.2f}")
+                                    st.metric(f"Top {cohort_pct}% Value", f"${top_s['end']:,.2f}")
                                     st.metric(f"Top {cohort_pct}% CAGR", f"{top_s['cagr']:.2f}%")
                             with m_col2:
                                 if bot_s:
-                                    st.metric(f"Bottom {cohort_pct}% (Inverse) Value", f"${bot_s['end']:,.2f}")
+                                    st.metric(f"Bottom {cohort_pct}% Value", f"${bot_s['end']:,.2f}")
                                     st.metric(f"Bottom {cohort_pct}% CAGR", f"{bot_s['cagr']:.2f}%")
 
                             # 7. Generate Plot using precomputed results
@@ -799,13 +796,15 @@ def main():
             if len(results['portfolio_values']) > 1:
                 yoy_returns = ['-']
                 for i in range(1, len(results['portfolio_values'])):
-                    ret = ((results['portfolio_values'][i] / results['portfolio_values'][i-1]) - 1) * 100
+                    val_curr = results['portfolio_values'][i]
+                    val_prev = results['portfolio_values'][i-1]
+                    ret = ((val_curr / val_prev) - 1) * 100 if val_prev > 0 else 0
                     yoy_returns.append(f"{ret:.2f}%")
-                perf_data['YoY Return'] = yoy_returns
+                perf_data['YoY/Period Return'] = yoy_returns
             
             if 'benchmark_returns' in results and results['benchmark_returns']:
-                # Benchmark returns are already in percentage format (like 34.62)
-                perf_data['Benchmark Return'] = ['-'] + [f"{r:.2f}%" for r in results['benchmark_returns']]
+                # Benchmark returns are decimals; multiply by 100 for percentage strings
+                perf_data['Benchmark Return'] = ['-'] + [f"{r*100:.2f}%" for r in results['benchmark_returns']]
             
             perf_df = pd.DataFrame(perf_data)
             st.dataframe(perf_df, use_container_width=True, hide_index=True)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -15,7 +15,6 @@ from . import factor_utils        # noqa: F401
 from . import fossil_fuel_restriction  # noqa: F401
 from . import portfolio           # noqa: F401
 from . import sector_selection    # noqa: F401
-from . import supabase_client     # noqa: F401
-from . import supabase_input      # noqa: F401
+
 from . import user_input          # noqa: F401
 from . import verbosity_options   # noqa: F401

--- a/src/calculate_holdings.py
+++ b/src/calculate_holdings.py
@@ -137,9 +137,12 @@ def calculate_holdings(factor, aum, market, restrict_fossil_fuels=False, top_pct
 
     return portfolio_new
 
-def calculate_growth(portfolio, current_market, verbosity=0):
+def calculate_growth(portfolio, current_market, next_market=None, verbosity=0):
     """
-    Calculates portfolio growth using the forward-looking 'Next_Year_Return' column.
+    Calculates portfolio growth for a single period.
+    
+    When next_market is provided (POC mode): uses price-to-price returns.
+    When next_market is None (Legacy mode): uses pre-computed Next_Year_Return column.
     """
     total_weighted_rtn = 0
     total_investment_value = 0
@@ -148,32 +151,39 @@ def calculate_growth(portfolio, current_market, verbosity=0):
         for inv in factor_portfolio.investments:
             ticker = inv["ticker"]
             
-            # Retrieve the pre-calculated total return from the current market object
-            try:
-                # Dividing by 100 because the data is in percentage format (e.g., 20.0 for 20%)
-                stock_rtn = current_market.stocks.loc[ticker, "Next_Year_Return"] / 100
+            entry_price = current_market.get_price(ticker)
+            
+            if next_market is not None:
+                # --- POC mode: price-to-price returns ---
+                exit_price = next_market.get_price(ticker)
                 
-                # Weight the return by the dollar value of the position at the start of the year
-                entry_price = current_market.get_price(ticker)
-                if entry_price:
+                if entry_price and entry_price > 0:
+                    if exit_price and exit_price > 0:
+                        stock_rtn = (exit_price / entry_price) - 1
+                    else:
+                        stock_rtn = 0.0  # Assume capital returned near last active price
+                    
                     position_value = inv["number_of_shares"] * entry_price
                     total_weighted_rtn += stock_rtn * position_value
                     total_investment_value += position_value
+            else:
+                # --- Legacy mode: use Next_Year_Return column ---
+                if entry_price and entry_price > 0:
+                    try:
+                        stock_rtn = current_market.stocks.loc[ticker, "Next_Year_Return"] / 100
+                    except KeyError:
+                        stock_rtn = 0.0
                     
-            except KeyError:
-                if verbosity >= 2:
-                    print(f"Warning: {ticker} return data missing, treating as 0%.")
-                continue
+                    position_value = inv["number_of_shares"] * entry_price
+                    total_weighted_rtn += stock_rtn * position_value
+                    total_investment_value += position_value
 
-    # Calculate aggregate growth for the year
     growth = total_weighted_rtn / total_investment_value if total_investment_value > 0 else 0
-    
-    # Calculate end value to maintain compatibility with the rebalancing loop
     total_end_value = total_investment_value * (1 + growth)
     
     return growth, total_investment_value, total_end_value
 
-def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, benchmark_index=1, verbosity=0, restrict_fossil_fuels=False, top_pct=10, which='top', use_market_cap_weight=False, factor_directions=None):
+def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, benchmark_index=1, verbosity=0, restrict_fossil_fuels=False, top_pct=10, which='top', use_market_cap_weight=False, factor_directions=None, frequency='Yearly', data_mode='poc'):
     """
     Executes a multi-year backtest. 
     Calculates Sharpe and Beta using year-specific excess returns.
@@ -183,55 +193,176 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, benchm
             When provided, overrides the global ``which`` on a per-factor basis.
     """
     aum = initial_aum
-    years = [start_year]
-    portfolio_returns = []  
-    portfolio_values = [aum]  
     
     verbosity = 0 if verbosity is None else verbosity
     risk_free_rate_source = "FRED 4 Week T-Bill (Oct 1)"
 
-    # --- 1. Annual Rebalancing Loop ---
-    for year in range(start_year, end_year):
-        market = MarketObject(data.loc[data['Year'] == year], year)
-        yearly_portfolio = []
+    if data_mode == 'legacy':
+        # ====================================================================
+        # LEGACY MODE: Year-based loop using Next_Year_Return column
+        # ====================================================================
+        years = [str(start_year)]
+        portfolio_returns = []
+        portfolio_values = [aum]
 
-        for factor in factors:
-            factor_which = which
-            if factor_directions:
-                col_name = getattr(factor, 'column_name', str(factor))
-                factor_which = factor_directions.get(col_name, which)
+        for year in range(start_year, end_year):
+            market = MarketObject(data.loc[data['Year'] == year], year)
+            yearly_portfolio = []
 
-            factor_portfolio = calculate_holdings(
-                factor=factor,
-                aum=aum / len(factors),
-                market=market,
-                restrict_fossil_fuels=restrict_fossil_fuels,
-                top_pct=top_pct,
-                which=factor_which,
-                use_market_cap_weight=use_market_cap_weight
-            )
-            yearly_portfolio.append(factor_portfolio)
+            for factor in factors:
+                factor_which = which
+                if factor_directions:
+                    col_name = getattr(factor, 'column_name', str(factor))
+                    factor_which = factor_directions.get(col_name, which)
 
-        # Calculate annual growth
-        growth, total_start_value, total_end_value = calculate_growth(yearly_portfolio, market, verbosity)
+                factor_portfolio = calculate_holdings(
+                    factor=factor,
+                    aum=aum / len(factors),
+                    market=market,
+                    restrict_fossil_fuels=restrict_fossil_fuels,
+                    top_pct=top_pct,
+                    which=factor_which,
+                    use_market_cap_weight=use_market_cap_weight
+                )
+                yearly_portfolio.append(factor_portfolio)
 
-        if verbosity >= 2:
-            print(f"Year {year} to {year + 1}: Growth: {growth:.2%}, Start: ${total_start_value:.2f}, End: ${total_end_value:.2f}")
+            # Legacy: calculate_growth with next_market=None uses Next_Year_Return
+            growth, total_start_value, total_end_value = calculate_growth(yearly_portfolio, market, None, verbosity)
 
-        aum = total_end_value  
-        portfolio_returns.append(growth)
-        portfolio_values.append(aum)
-        years.append(year + 1)
+            if verbosity >= 2:
+                print(f"Year {year} to {year + 1}: Growth: {growth:.2%}, Start: ${total_start_value:.2f}, End: ${total_end_value:.2f}")
 
-    # --- 2. Data Alignment (Benchmarks & Risk-Free) ---
-    # Fetched from benchmarks.py to ensure data integrity across the range
-    rf_list = get_benchmark_list(4, start_year, end_year)
-    bench_list = get_benchmark_list(benchmark_index, start_year + 1, end_year + 1)
+            aum = total_end_value
+            portfolio_returns.append(growth)
+            portfolio_values.append(aum)
+            years.append(str(year + 1))
 
-    # Convert to NumPy for performance math
-    portfolio_returns_np = np.array(portfolio_returns)
-    rf_rates_np = np.array(rf_list)
-    benchmark_returns_np = np.array(bench_list) / 100 
+        # Legacy benchmarks from benchmarks.py (returns are in %, convert to decimals)
+        rf_list = get_benchmark_list(4, start_year, end_year)
+        bench_list = [r / 100 for r in get_benchmark_list(benchmark_index, start_year + 1, end_year + 1)]
+
+        portfolio_returns_np = np.array(portfolio_returns)
+        rf_rates_np = np.array(rf_list)
+        benchmark_returns_np = np.array(bench_list)
+
+    else:
+        # ====================================================================
+        # POC MODE: Date-based loop using price-to-price returns (UNCHANGED)
+        # ====================================================================
+        data = data.copy()
+        data['Date'] = pd.to_datetime(data['Date'])
+
+        if frequency == 'Monthly':
+            dates = data.groupby([data['Date'].dt.year, data['Date'].dt.month])['Date'].max().values
+        elif frequency == 'Quarterly':
+            dates = data.groupby([data['Date'].dt.year, data['Date'].dt.quarter])['Date'].max().values
+        else:  # Yearly
+            dates = data.groupby(data['Date'].dt.year)['Date'].max().values
+            
+        dates = pd.to_datetime(dates)
+        start_dt = pd.Timestamp(year=start_year, month=1, day=1)
+        end_dt = pd.Timestamp(year=end_year, month=12, day=31)
+        
+        dates = dates[(dates >= start_dt) & (dates <= end_dt)]
+        dates = sorted(dates.unique())
+        
+        if len(dates) < 2:
+            raise ValueError("Not enough overlapping dates to run a backtest. Please widen your date bounds.")
+            
+        time_labels = [d.strftime('%Y-%m-%d') for d in dates]
+        years = time_labels
+        portfolio_returns = []  
+        portfolio_values = [aum]  
+        benchmark_returns = []
+
+        # --- 1. Rebalancing Loop ---
+        for i in range(len(dates) - 1):
+            current_date = dates[i]
+            next_date = dates[i+1]
+            
+            market = MarketObject(data[data['Date'] == current_date], current_date)
+            next_market = MarketObject(data[data['Date'] == next_date], next_date)
+            
+            yearly_portfolio = []
+
+            for factor in factors:
+                factor_which = which
+                if factor_directions:
+                    col_name = getattr(factor, 'column_name', str(factor))
+                    factor_which = factor_directions.get(col_name, which)
+
+                factor_portfolio = calculate_holdings(
+                    factor=factor,
+                    aum=aum / len(factors),
+                    market=market,
+                    restrict_fossil_fuels=restrict_fossil_fuels,
+                    top_pct=top_pct,
+                    which=factor_which,
+                    use_market_cap_weight=use_market_cap_weight
+                )
+                yearly_portfolio.append(factor_portfolio)
+
+            # Calculate period growth for the invested portion
+            _, total_start_value, total_end_value = calculate_growth(yearly_portfolio, market, next_market, verbosity)
+
+            # Retain cash that was not allocated to any valid stocks
+            uninvested_cash = aum - total_start_value
+            new_aum = total_end_value + uninvested_cash
+            
+            actual_growth = (new_aum / aum) - 1 if aum > 0 else 0
+
+            # POC benchmark return (Market-Cap Weighted Universe)
+            try:
+                entry_prices = market.stocks['Ending Price']
+                entry_prices = entry_prices[~entry_prices.index.duplicated(keep='first')]
+                
+                mcaps = market.stocks.get('Market Capitalization', None)
+                if mcaps is not None:
+                    mcaps = mcaps[~mcaps.index.duplicated(keep='first')]
+                
+                exit_prices = next_market.stocks['Ending Price']
+                exit_prices = exit_prices[~exit_prices.index.duplicated(keep='first')]
+                
+                exit_prices = exit_prices.reindex(entry_prices.index)
+                returns = (exit_prices / entry_prices) - 1
+                returns = returns.fillna(0.0)
+                valid_returns = returns[entry_prices > 0]
+                
+                if mcaps is not None:
+                    valid_mcaps = mcaps.reindex(valid_returns.index).fillna(0.0)
+                    total_mcap = valid_mcaps.sum()
+                    if total_mcap > 0:
+                        bench_ret = (valid_returns * valid_mcaps).sum() / total_mcap
+                    else:
+                        bench_ret = valid_returns.mean()
+                else:
+                    bench_ret = valid_returns.mean() if not valid_returns.empty else 0.0
+            except Exception as e:
+                if verbosity >= 2:
+                    print(f"Benchmark eval exception: {e}")
+                bench_ret = 0.0
+                
+            benchmark_returns.append(bench_ret)
+
+            if verbosity >= 2:
+                print(f"{current_date.date()} to {next_date.date()}: Growth: {actual_growth:.2%}, Start: ${aum:.2f}, End: ${new_aum:.2f} (Uninvested: ${uninvested_cash:.2f}) | Bench: {bench_ret:.2%}")
+
+            aum = new_aum  
+            portfolio_returns.append(actual_growth)
+            portfolio_values.append(aum)
+
+        # --- 2. Data Alignment (Benchmarks & Risk-Free) ---
+        rf_list = get_benchmark_list(4, start_year, end_year)
+        if len(rf_list) > len(portfolio_returns):
+            rf_list = rf_list[:len(portfolio_returns)]
+        elif len(rf_list) < len(portfolio_returns):
+            rf_list = rf_list + [rf_list[-1] if rf_list else 0] * (len(portfolio_returns) - len(rf_list))
+
+        bench_list = benchmark_returns
+
+        portfolio_returns_np = np.array(portfolio_returns)
+        rf_rates_np = np.array(rf_list) / 100 
+        benchmark_returns_np = np.array(bench_list)
     
 # --- 3. Excess Return Calculations ---
     excess_portfolio_returns = portfolio_returns_np - rf_rates_np
@@ -327,8 +458,7 @@ def calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity=
     # Ensure inputs are numpy arrays for mathematical operations
     verbosity = 0 if verbosity is None else verbosity
     portfolio_returns = np.array(portfolio_returns)
-    #benchmark_returns = np.array(benchmark_returns)
-    benchmark_returns = np.array(benchmark_returns) / 100
+    benchmark_returns = np.array(benchmark_returns)
 
     # Calculate active returns
     active_returns = portfolio_returns - benchmark_returns

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@ from .calculate_holdings import rebalance_portfolio
 from .user_input import get_factors
 from .verbosity_options import get_verbosity_level
 from .fossil_fuel_restriction import get_fossil_fuel_restriction
-from .supabase_input import get_supabase_preference, get_data_loading_verbosity
+from .supabase_input import get_data_loading_verbosity
 from .sector_selection import get_sector_selection
 from Visualizations.portfolio_growth_plot import plot_portfolio_growth
 import pandas as pd
@@ -12,9 +12,6 @@ import matplotlib.pyplot as plt
 def main():
     ### Ask about fossil fuel restriction first ###
     restrict_fossil_fuels = get_fossil_fuel_restriction()  # Prompt user (Yes/No)
-
-    ### Ask about data source ###
-    use_supabase = get_supabase_preference()
     
     # Ask about data loading verbosity
     show_loading = get_data_loading_verbosity()
@@ -25,7 +22,6 @@ def main():
     # Load market data
     rdata = load_data(
         restrict_fossil_fuels=restrict_fossil_fuels, 
-        use_supabase=use_supabase,
         show_loading_progress=show_loading,
         sectors=selected_sectors
     )
@@ -67,7 +63,7 @@ def main():
     # ...existing code...
     results = rebalance_portfolio(
         rdata, list(factor_objects),
-        start_year=2002, end_year=2023,
+        start_year=2008, end_year=2023,
         initial_aum=1,
         verbosity=verbosity_level,
         restrict_fossil_fuels=restrict_fossil_fuels

--- a/src/market_object.py
+++ b/src/market_object.py
@@ -4,7 +4,7 @@ from .supabase_client import load_supabase_data
 import os
 
 ### CREATING FUNCTION TO LOAD DATA ### Tables: FR2000 Annual Quant Data Full Precision Test
-def load_data(restrict_fossil_fuels=False, use_supabase=True, table_name='Full Precision Test', show_loading_progress=True, data_path=None, excel_sheet='Data', sectors=None):
+def load_data(restrict_fossil_fuels=False, use_supabase=None, table_name='Full Precision Test', show_loading_progress=True, data_path=None, excel_sheet='Data', sectors=None):
     """
     Load market data from either Supabase or Excel file (fallback).
     
@@ -17,6 +17,23 @@ def load_data(restrict_fossil_fuels=False, use_supabase=True, table_name='Full P
     Returns:
         pandas.DataFrame: Market data
     """
+    
+    # Auto-detect local daily CSV file; prefer it over Supabase when available
+    local_csv_path = os.path.join(os.path.dirname(__file__), '..', 'data', 'russell2000_cleaned.csv')
+    if use_supabase is None:
+        if data_path is not None:
+            use_supabase = False
+        elif os.path.exists(local_csv_path):
+            data_path = local_csv_path
+            use_supabase = False
+            if show_loading_progress:
+                print(f"Loading data from local CSV: {os.path.abspath(local_csv_path)}")
+        else:
+            use_supabase = True
+    elif use_supabase is False and data_path is None:
+        # Explicit use_supabase=False but no path — auto-fill with local CSV if available
+        if os.path.exists(local_csv_path):
+            data_path = local_csv_path
     
     if use_supabase:
         try:
@@ -147,57 +164,73 @@ def load_data(restrict_fossil_fuels=False, use_supabase=True, table_name='Full P
             # Standardize to the same column names we expect from Supabase
             rdata = _standardize_column_names(rdata)
             
-            # New return logic: 0 if null next year return
-            rdata['Next_Year_Return'] = rdata['Next_Year_Return'].fillna(0)
-
-            # Apply sector restriction logic (post-standardization)
-            if restrict_fossil_fuels:
-                industry_col = 'FactSet Industry'
-                if industry_col in rdata.columns:
-                    before = rdata.copy()
-                    rdata[industry_col] = rdata[industry_col].astype(str).str.lower()
-                    fossil_keywords = ['oil', 'gas', 'coal', 'energy', 'fossil']
-                    mask = rdata[industry_col].apply(lambda x: not any(kw in x for kw in fossil_keywords))
-                    rdata = rdata[mask]
-                    # Report removals (tickers)
-                    if 'Ticker' in before.columns and 'Ticker' in rdata.columns:
-                        removed = sorted(set(before['Ticker']) - set(rdata['Ticker']))
-                        if removed:
-                            print(f"Fossil filter removed {len(removed)} tickers (Excel/CSV): {', '.join(removed[:25])}{' ...' if len(removed) > 25 else ''}")
-                        else:
-                            print("Fossil filter removed 0 tickers (Excel/CSV)")
-                else:
-                    print("Warning: 'FactSet Industry' column not found. Fossil fuel filtering skipped.")
-
-            # If sectors are provided, apply client-side filter
-            if sectors:
-                rdata = _apply_sector_filter(rdata, sectors, context_label="File")
-
-            # Remove duplicate rows and rows with missing essential data (prices/tickers/dates)
-            try:
-                before_total = len(rdata)
-                # Drop exact duplicate rows
-                rdata = rdata.drop_duplicates()
-                dup_removed = before_total - len(rdata)
-
-                # Filter out rows missing essential data
-                rdata_before_filter = rdata.copy()
-                rdata = _filter_essential_data(rdata)
-                nulls_removed = len(rdata_before_filter) - len(rdata)
-
-                if dup_removed > 0 or nulls_removed > 0:
-                    print(f"File load: removed {dup_removed} duplicate rows and {nulls_removed} rows with missing essential data (out of {before_total} rows).")
-            except Exception:
-                pass
-
-            print(f"Successfully loaded {len(rdata)} records from file")
-            # Quick sanity check: distribution by Year after standardization
+            # --- CRSP daily CSV preprocessing ---
+            # Parse Date column
+            if 'Date' not in rdata.columns and 'date' in rdata.columns:
+                rdata['Date'] = rdata['date']
+            if 'Date' in rdata.columns:
+                rdata['Date'] = pd.to_datetime(rdata['Date'], format='mixed', errors='coerce')
+                rdata = rdata.dropna(subset=['Date'])
+            
+            # Derive Year from Date if not already present
+            if 'Year' not in rdata.columns and 'Date' in rdata.columns:
+                rdata['Year'] = rdata['Date'].dt.year
+            
+            # Filter out pre-2008 rows for performance (keep 2007+ for lookback data)
             if 'Year' in rdata.columns:
-                try:
-                    year_counts = rdata['Year'].value_counts().sort_index()
-                    print("Rows per Year (File):", ", ".join([f"{int(y)}: {int(c)}" for y, c in year_counts.items()]))
-                except Exception:
-                    pass
+                before_count = len(rdata)
+                rdata = rdata[rdata['Year'] >= 2008]
+                filtered_count = before_count - len(rdata)
+                if filtered_count > 0 and show_loading_progress:
+                    print(f"Filtered out {filtered_count} rows from before 2008.")
+            
+            # Filter out rows with missing essential data
+            essential_missing = 0
+            for col in ['Ending Price', 'Ticker', 'Date']:
+                if col in rdata.columns:
+                    before_len = len(rdata)
+                    rdata = rdata.dropna(subset=[col])
+                    essential_missing += before_len - len(rdata)
+            if essential_missing > 0 and show_loading_progress:
+                print(f"Filtered out {essential_missing} rows with missing essential data (price, ticker, or date)")
+            
+            # Remove duplicates and incomplete rows
+            before_dup = len(rdata)
+            rdata = rdata.drop_duplicates()
+            dup_removed = before_dup - len(rdata)
+            if show_loading_progress:
+                print(f"Removed {dup_removed} duplicates and {essential_missing} incomplete rows.")
+            
+            # Compute custom momentum factors from daily prices
+            momentum_factors = {
+                '1-Mo Momentum %': 21,    # ~21 trading days ≈ 1 month
+                '6-Mo Momentum %': 126,   # ~126 trading days ≈ 6 months
+                '12-Mo Momentum %': 252,  # ~252 trading days ≈ 12 months
+            }
+            needs_momentum = any(
+                col not in rdata.columns for col in momentum_factors
+            )
+            if needs_momentum and 'Ending Price' in rdata.columns and 'Ticker' in rdata.columns:
+                if show_loading_progress:
+                    print("Calculating custom factor momentum...")
+                # Sort by Ticker and Date for proper pct_change calculation
+                rdata = rdata.sort_values(['Ticker', 'Date']).reset_index(drop=True)
+                for col_name, lookback_days in momentum_factors.items():
+                    if col_name not in rdata.columns:
+                        rdata[col_name] = rdata.groupby('Ticker')['Ending Price'].pct_change(lookback_days, fill_method=None) * 100
+
+            # New return logic: 0 if null next year return
+            if 'Next_Year_Return' in rdata.columns:
+                rdata['Next_Year_Return'] = rdata['Next_Year_Return'].fillna(0)
+
+            if show_loading_progress:
+                print(f"Successfully loaded {len(rdata)} records")
+                if 'Year' in rdata.columns:
+                    try:
+                        year_counts = rdata['Year'].value_counts().sort_index()
+                        print("Rows per Year:", ", ".join([f"{int(y)}: {int(c)}" for y, c in year_counts.items()]))
+                    except Exception:
+                        pass
             return rdata
 
         except Exception as e:
@@ -258,7 +291,9 @@ def _standardize_column_names(df):
     
     # Ensure required columns exist (with fallback logic)
     if 'Ticker' not in df.columns:
-        if 'Ticker-Region' in df.columns:
+        if 'ticker' in df.columns:
+            df['Ticker'] = df['ticker']
+        elif 'Ticker-Region' in df.columns:
             df['Ticker'] = df['Ticker-Region'].str.split('-').str[0].str.strip()
         elif 'ticker_region' in df.columns:
             df['Ticker'] = df['ticker_region'].str.split('-').str[0].str.strip()
@@ -272,6 +307,17 @@ def _standardize_column_names(df):
     # Ensure Ticker-Region exists if we have ticker_region in lowercase
     if 'Ticker-Region' not in df.columns and 'ticker_region' in df.columns:
         df['Ticker-Region'] = df['ticker_region']
+    
+    # Map raw CRSP price to Ending Price if not present
+    if 'Ending Price' not in df.columns and 'prc' in df.columns:
+        if 'cfacpr' in df.columns:
+            df['Ending Price'] = df['prc'].abs() / df['cfacpr']
+        else:
+            df['Ending Price'] = df['prc'].abs()  # CRSP sets negative prices for bid/ask averages
+    
+    # Derive Market Capitalization if raw CRSP shares data is available
+    if 'Market Capitalization' not in df.columns and 'prc' in df.columns and 'shrout' in df.columns:
+        df['Market Capitalization'] = df['prc'].abs() * df['shrout']
     
     return df
 
@@ -370,14 +416,14 @@ class MarketObject():
 
         # Define relevant columns
         available_factors = [
-            'ROE using 9/30 Data', 'ROA using 9/30 Data', '12-Mo Momentum %', '1-Mo Momentum %',
+            'ROE using 9/30 Data', 'ROA using 9/30 Data', '12-Mo Momentum %', '6-Mo Momentum %', '1-Mo Momentum %',
             'Price to Book Using 9/30 Data', 'Next FY Earns/P', '1-Yr Price Vol %', 'Accruals/Assets',
             'ROA %', '1-Yr Asset Growth %', '1-Yr CapEX Growth %', 'Book/Price',
             "Next_Year_Return", "Next-Year's Active Return %"
         ]
         # Keep Ticker-Region so we can index uniquely when present
         # Include Market Capitalization for cap-weighted portfolios
-        keep_cols = ['Ticker-Region', 'Ticker', 'Ending Price', 'Year', '6-Mo Momentum %', 'FactSet Industry', 'Market Capitalization'] + available_factors
+        keep_cols = ['Ticker-Region', 'Ticker', 'Ending Price', 'Year', 'Date', 'FactSet Industry', 'Market Capitalization'] + available_factors
 
         # Filter and clean data
         data = data[[col for col in keep_cols if col in data.columns]].copy()


### PR DESCRIPTION
## Summary

This PR introduces sub-annual (Monthly/Quarterly) rebalancing using daily CRSP price data, along with a UI toggle to switch between the new **POC daily data pipeline** and the original **Legacy Supabase annual data**.

## Key Changes

### Data Pipeline (`src/market_object.py`)
- Auto-detect local daily CSV (`data/russell2000_cleaned.csv`, 7M+ records) when available
- Derive split-adjusted `Ending Price` from `prc/cfacpr` and `Market Capitalization` from `prc*shrout`
- Compute all 3 momentum factors from daily prices: 1-Mo (21d), 6-Mo (126d), 12-Mo (252d)

### Rebalancing Engine (`src/calculate_holdings.py`)
- `rebalance_portfolio()` now accepts `data_mode='poc'|'legacy'` and `frequency='Monthly'|'Quarterly'|'Yearly'`
- **POC mode**: Date-based loop with price-to-price returns
- **Legacy mode**: Year-based loop with `Next_Year_Return` column (preserved)
- Cap-weighted benchmark computed from the full universe each period

### Streamlit UI (`app/streamlit_app.py`)
- Data Source toggle: 📊 POC (Daily CRSP) vs 📁 Legacy (Supabase)
- Dynamic factor selector: POC shows momentum-only; Legacy shows all 13 factors
- Frequency locked to Yearly in Legacy mode
- Fixed cohort CAGR calculation (calendar years instead of period count)

### Visualization (`Visualizations/top_bottom_portfolio_plot.py`)
- Fixed cohort plot x-axis for date-string labels with tick thinning

## Verification
- ✅ 69/69 unit tests pass
- ✅ POC Monthly/Quarterly/Yearly all verified with real returns
- ✅ Legacy mode produces correct portfolio growth with Supabase data

## Test Results (POC, 6-Mo Momentum, 2010-2022)

| Frequency | Periods | Final AUM | CAGR | Sharpe |
|-----------|---------|-----------|------|--------|
| Monthly | 155 | $644,763 | 15.52% | 0.2274 |
| Quarterly | 51 | $378,912 | 11.01% | 0.2758 |
| Yearly | 12 | $230,513 | 7.21% | 0.4817 |
