### PR TITLE
integrated daily supabase data + volatility weighting

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -263,8 +263,29 @@ def main():
         st.subheader("Data Source")
         st.caption("Data source: Supabase (cloud)")
         use_supabase = True
-        excel_file = None
-        uploaded_file = None
+        
+        # Data is loaded at daily granularity by default for accuracy
+        # Yearly (legacy) option preserved for backward compatibility with 2002-2023 data
+        data_frequency = st.radio(
+            "Data Frequency:",
+            options=["Daily", "Yearly (Legacy)"],
+            index=0,
+            help="Daily uses point-in-time daily prices for accurate compounding. Yearly (Legacy) uses the original annual factor data (2002-2023)."
+        )
+        # Map display label back to internal value
+        if data_frequency == "Yearly (Legacy)":
+            data_frequency = "Yearly"
+
+        # Rebalance frequency options depend on data frequency
+        if data_frequency == "Daily":
+            rebalance_frequency = st.radio(
+                "Rebalance Frequency:",
+                options=["Daily", "Monthly", "Quarterly", "Yearly"],
+                index=1,  # Default Monthly
+                help="How often to reconstruct the portfolio. Between rebalances, existing holdings compound daily returns."
+            )
+        else:
+            rebalance_frequency = "Yearly"
 
         st.write("---")
         # Fossil Fuel Restriction
@@ -277,16 +298,29 @@ def main():
         st.write("---")
         # Portfolio Weighting Method
         st.subheader("Portfolio Weighting")
+        weighting_options = ["Equal Weight", "Market Cap Weight", "Volatility Weighted"]
+
         weighting_method = st.radio(
             "Select weighting method:",
-            options=["Equal Weight", "Market Cap Weight"],
+            options=weighting_options,
             index=0,
-            help="Equal Weight: Each stock gets equal dollar investment. Market Cap Weight: Weight by market capitalization (similar to Russell 2000)"
+            help="Equal: Each stock gets equal dollar investment. Market Cap: Weight by market capitalization. Volatility: Weight inversely by volatility to hit a target (only available for Monthly and Daily data)."
         )
         use_market_cap_weight = (weighting_method == "Market Cap Weight")
         
         if use_market_cap_weight:
-            st.info("📊 Market Cap Weighting: Stocks will be weighted by their market capitalization, similar to the Russell 2000 index. This reduces turnover costs and aligns with market performance.")
+            st.info("📊 Market Cap Weighting: Stocks will be weighted by their market capitalization, similar to the Russell 2000 index.")
+            
+        target_volatility = None
+        volatility_metric = None
+        if weighting_method == "Volatility Weighted":
+            st.info("📉 Inverse-Volatility Weighting (Risk Parity): Stocks are weighted inversely proportional to their volatility. Lower-vol stocks get larger allocations.")
+            volatility_metric = st.selectbox(
+                "Volatility Metric",
+                options=["vol_gk_1m", "vol_gk_3m", "vol_gk_6m", "vol_gk_12m", "vol_close_1m", "vol_close_3m", "vol_close_6m", "vol_close_12m"],
+                index=0,
+                help="Which metric to use to measure stock volatility (GK = Garman-Klass, Close = standard closing returns)."
+            )
         
         st.write("---")
         # Sector Selection
@@ -342,7 +376,7 @@ def main():
             "Initial AUM ($)",
             min_value=0.0,
             max_value=1000000000.0,
-            value=1000.0,
+            value=1000000.0,
             step=100.0,
             format="%.0f",
             help="Starting portfolio value in dollars"
@@ -450,63 +484,91 @@ def main():
         col1, col2, col3 = st.columns([1, 2, 1])
         with col2:
             if st.button("Load Data", use_container_width=True, type="primary"):
-                # Prevemt re-loading if data is already loaded
-                if not st.session_state.data_loaded:
-                    with st.spinner("Loading market data..."):
-                        try:
-                            sectors_to_use = selected_sectors if sector_filter_enabled else None
+                # Reset session state so each click does a fresh load
+                st.session_state.data_loaded = False
+                st.session_state.rdata = None
+                st.session_state.results = None
+                if True:
+                    try:
+                        sectors_to_use = selected_sectors if sector_filter_enabled else None
 
-                            rdata = load_data(
-                                restrict_fossil_fuels=restrict_fossil_fuels,
+                        @st.cache_data(show_spinner="Loading daily market data...", ttl=3600)
+                        def cached_load_data(_restrict_ff, _data_freq, _sectors, _start, _end):
+                            return load_data(
+                                restrict_fossil_fuels=_restrict_ff,
                                 use_supabase=True,
-                                data_path=None,
-                                show_loading_progress=show_loading,
-                                sectors=sectors_to_use
+                                data_frequency=_data_freq,
+                                show_loading_progress=True,
+                                sectors=_sectors,
+                                start_year=_start,
+                                end_year=_end
                             )
+                        
+                        sectors_key = tuple(sorted(sectors_to_use)) if sectors_to_use else None
+                        rdata = cached_load_data(
+                            restrict_fossil_fuels,
+                            data_frequency,
+                            sectors_key,
+                            int(start_year),
+                            int(end_year)
+                        )
 
-                            # Data preprocessing
+                        if rdata is None or rdata.empty:
+                            st.error(f"No {data_frequency} data found in the database between {start_year} and {end_year}. Please expand your Analysis Period.")
+                            st.stop()
+
+                        # Data preprocessing
+                        if 'Ticker' not in rdata.columns and 'Ticker-Region' in rdata.columns:
                             rdata['Ticker'] = rdata['Ticker-Region'].dropna().apply(
-                                lambda x: x.split('-')[0].strip()
+                                lambda x: str(x).split('-')[0].strip()
                             )
-                            rdata['Year'] = pd.to_datetime(rdata['Date']).dt.year
+                        if 'Year' not in rdata.columns:
+                            if 'Date' in rdata.columns:
+                                rdata['Year'] = pd.to_datetime(rdata['Date']).dt.year
+                            elif 'date' in rdata.columns:
+                                rdata['Year'] = pd.to_datetime(rdata['date']).dt.year
 
-                            # If the user selected an analysis period, filter the loaded data to that range
-                            try:
-                                rdata = rdata[(rdata['Year'] >= int(start_year)) & (rdata['Year'] <= int(end_year))]
-                            except Exception:
-                                # If filtering fails, keep full dataset but warn the user
-                                st.warning('Unable to filter loaded data by selected years; using full dataset instead.')
+                        # If the user selected an analysis period, filter the loaded data to that range
+                        try:
+                            rdata = rdata[(rdata['Year'] >= int(start_year)) & (rdata['Year'] <= int(end_year))]
+                        except Exception:
+                            st.warning('Unable to filter loaded data by selected years; using full dataset instead.')
 
-                            # Keep only relevant columns (include Market Capitalization for cap-weighted portfolios)
-                            cols_to_keep = ['Ticker', 'Year', 'Next_Year_Return']
-                            if 'Ending Price' in rdata.columns:
-                                cols_to_keep.append('Ending Price')
-                            elif 'Ending_Price' in rdata.columns:
-                                rdata['Ending Price'] = rdata['Ending_Price']
-                                cols_to_keep.append('Ending Price')
+                        # Keep only relevant columns
+                        cols_to_keep = ['Ticker', 'Year', 'Next_Year_Return']
+                        
+                        if 'Period' in rdata.columns:
+                            cols_to_keep.append('Period')
+                        
+                        if 'Ending Price' in rdata.columns:
+                            cols_to_keep.append('Ending Price')
+                        elif 'Ending_Price' in rdata.columns:
+                            rdata['Ending Price'] = rdata['Ending_Price']
+                            cols_to_keep.append('Ending Price')
+                        
+                        if 'Market Capitalization' in rdata.columns:
+                            cols_to_keep.append('Market Capitalization')
+                        elif 'Market_Capitalization' in rdata.columns:
+                            rdata['Market Capitalization'] = rdata['Market_Capitalization']
+                            cols_to_keep.append('Market Capitalization')
+
+                        if weighting_method == "Volatility Weighted" and volatility_metric in rdata.columns:
+                            cols_to_keep.append(volatility_metric)
                             
-                            # Add Market Capitalization if available (needed for cap-weighted portfolios)
-                            if 'Market Capitalization' in rdata.columns:
-                                cols_to_keep.append('Market Capitalization')
-                            elif 'Market_Capitalization' in rdata.columns:
-                                rdata['Market Capitalization'] = rdata['Market_Capitalization']
-                                cols_to_keep.append('Market Capitalization')
+                        for factor in FACTOR_MAP.keys():
+                            if factor in rdata.columns:
+                                cols_to_keep.append(factor)
 
-                            for factor in FACTOR_MAP.keys():
-                                if factor in rdata.columns:
-                                    cols_to_keep.append(factor)
+                        rdata = rdata[cols_to_keep]
 
-                            rdata = rdata[cols_to_keep]
+                        st.session_state.rdata = rdata
+                        st.session_state.data_loaded = True
 
-                            st.session_state.rdata = rdata
-                            st.session_state.data_loaded = True
+                        st.success(f"Data loaded successfully! {len(rdata)} records from {rdata['Year'].min()} to {rdata['Year'].max()}")
 
-
-                            st.success(f"Data loaded successfully! {len(rdata)} records from {rdata['Year'].min()} to {rdata['Year'].max()}")
-
-                        except Exception as e:
-                            st.error(f"Error loading data: {str(e)}")
-                            st.exception(e)
+                    except Exception as e:
+                        st.error(f"Error loading data: {str(e)}")
+                        st.exception(e)
                 
                 
         # Show data preview
@@ -544,7 +606,12 @@ def main():
                                     verbosity=verbosity_level,
                                     restrict_fossil_fuels=restrict_fossil_fuels,
                                     use_market_cap_weight=use_market_cap_weight,
-                                    factor_directions=factor_directions
+                                    factor_directions=factor_directions,
+                                    weighting_method=weighting_method,
+                                    target_volatility=target_volatility,
+                                    volatility_metric=volatility_metric,
+                                    data_frequency=data_frequency,
+                                    rebalance_frequency=rebalance_frequency
                                 )
                                 
                                 st.session_state.results = results
@@ -553,6 +620,11 @@ def main():
                                 st.session_state.restrict_ff = restrict_fossil_fuels
                                 st.session_state.initial_aum = initial_aum
                                 st.session_state.use_cap_weight = use_market_cap_weight
+                                st.session_state.weighting_method = weighting_method
+                                st.session_state.target_volatility = target_volatility
+                                st.session_state.volatility_metric = volatility_metric
+                                st.session_state.data_frequency = data_frequency
+                                st.session_state.rebalance_frequency = rebalance_frequency
                                 
                                 st.success("Analysis complete! Check the Results tab.")
                             
@@ -576,7 +648,11 @@ def main():
                 ]
                 st.caption(f"**Factors:** {', '.join(factor_captions)}")
             with col2:
-                weighting_label = "Market Cap Weighted" if st.session_state.get('use_cap_weight', False) else "Equal Weighted"
+                weighting_label = st.session_state.get('weighting_method', 'Equal Weight')
+                if weighting_label == "Volatility Weighted":
+                    tgt = st.session_state.get('target_volatility', 15.0)
+                    met = st.session_state.get('volatility_metric', '')
+                    weighting_label += f" ({tgt}% target using {met})"
                 st.caption(f"**Weighting:** {weighting_label}")
             
             st.divider()
@@ -595,8 +671,16 @@ def main():
                 st.metric("Total Return", f"{total_return:.2f}%")
             
             with col3:
-                years = len(results['years'])
-                cagr = (((final_value / st.session_state.initial_aum) ** (1/years)) - 1) * 100
+                n_periods = len(results['years'])
+                data_freq = st.session_state.get('data_frequency', 'Yearly')
+                if data_freq == 'Monthly':
+                    n_years = n_periods / 12.0
+                elif data_freq == 'Daily':
+                    n_years = n_periods / 252.0
+                else:
+                    n_years = float(n_periods)
+                n_years = max(n_years, 1.0 / 252.0)  # prevent division by zero
+                cagr = (((final_value / st.session_state.initial_aum) ** (1 / n_years)) - 1) * 100
                 st.metric("CAGR", f"{cagr:.2f}%")
             
             with col4:
@@ -618,47 +702,103 @@ def main():
             years = results['years']
             portfolio_values = results['portfolio_values']
             initial_aum = st.session_state.initial_aum
+            is_sub_annual = results.get('data_frequency', 'Yearly') in ['Monthly', 'Daily']
             
-            ax.plot(years, portfolio_values, marker='o', linewidth=2, markersize=6, label='Portfolio', color='#1f77b4')
+            if is_sub_annual:
+                # Use sequential integer x-axis, map to period labels
+                x_vals = list(range(len(years)))
+                ax.plot(x_vals, portfolio_values, marker='o', linewidth=2, markersize=3, label='Portfolio', color='#1f77b4')
+                # Show every Nth label to avoid overlap
+                n_labels = min(12, len(years))
+                step = max(1, len(years) // n_labels)
+                tick_positions = list(range(0, len(years), step))
+                ax.set_xticks(tick_positions)
+                ax.set_xticklabels([str(years[i]) for i in tick_positions], rotation=45, ha='right', fontsize=8)
+                ax.set_xlabel('Period', fontsize=12)
+            else:
+                ax.plot(years, portfolio_values, marker='o', linewidth=2, markersize=6, label='Portfolio', color='#1f77b4')
+                ax.set_xlabel('Year', fontsize=12)
             
-            # 1. Existing Russell 2000 Benchmark
+            # Benchmark overlays
             if 'benchmark_returns' in results and results['benchmark_returns']:
                 benchmark_values = [initial_aum]
                 for ret in results['benchmark_returns']:
                     benchmark_values.append(benchmark_values[-1] * (1 + ret / 100))
-                ax.plot(years, benchmark_values, marker='s', linewidth=2, markersize=4, 
-                       label='Russell 2000', linestyle='--', alpha=0.7, color='#ff7f0e')
+                
+                if is_sub_annual:
+                    # Map yearly benchmark values to x-positions
+                    year_end_positions = []
+                    for yr_idx in range(len(benchmark_values)):
+                        if yr_idx == 0:
+                            # Initial value maps to the very first period
+                            year_end_positions.append(0)
+                        else:
+                            # Value at end of year N maps to December of that year
+                            yr = start_year + (yr_idx - 1)
+                            dec_label = f"{yr}-12"
+                            if dec_label in years:
+                                year_end_positions.append(years.index(dec_label))
+                            else:
+                                yr_periods = [i for i, p in enumerate(years) if str(p).startswith(str(yr))]
+                                if yr_periods:
+                                    year_end_positions.append(yr_periods[-1])
+                                else:
+                                    year_end_positions.append(None)
+                    # Filter out Nones and plot
+                    valid = [(pos, val) for pos, val in zip(year_end_positions, benchmark_values) if pos is not None]
+                    if valid:
+                        bx, bv = zip(*valid)
+                        ax.plot(list(bx), list(bv), marker='s', linewidth=2, markersize=5,
+                               label='Russell 2000', linestyle='--', alpha=0.7, color='#ff7f0e')
+                else:
+                    ax.plot(years, benchmark_values, marker='s', linewidth=2, markersize=4, 
+                           label='Russell 2000', linestyle='--', alpha=0.7, color='#ff7f0e')
 
-            # === ADDED: VALUE AND GROWTH OVERLAYS ===
             try:
                 from src.benchmarks import get_benchmark_list
-                
-                # Fetch returns (Index 3: Value, Index 2: Growth)
-                val_rets = get_benchmark_list(3, years[0] + 1, years[-1] + 2)
-                gro_rets = get_benchmark_list(2, years[0] + 1, years[-1] + 2)
+                val_rets = get_benchmark_list(3, start_year + 1, (start_year + len(results.get('benchmark_returns', []))) + 1)
+                gro_rets = get_benchmark_list(2, start_year + 1, (start_year + len(results.get('benchmark_returns', []))) + 1)
 
                 indices_to_plot = [
                     ('Value Index', val_rets, 'g', '^'),
                     ('Growth Index', gro_rets, 'orange', 'D')
                 ]
 
-                for label, rets, color, marker in indices_to_plot:
+                for label, rets, color, mkr in indices_to_plot:
                     if rets:
                         vals = [initial_aum]
                         for r in rets:
                             vals.append(vals[-1] * (1 + float(r) / 100))
-                        
-                        # Align lengths: Ensure we only plot the intersection of years and values
-                        common_len = min(len(years), len(vals))
-                        ax.plot(years[:common_len], vals[:common_len], 
-                               marker=marker, linestyle=':', linewidth=1.5, 
-                               alpha=0.6, label=label, color=color)
+                        if is_sub_annual:
+                            # Same approach: map to year-end x-positions
+                            idx_positions = []
+                            for yr_idx in range(len(vals)):
+                                if yr_idx == 0:
+                                    idx_positions.append(0)
+                                else:
+                                    yr = start_year + (yr_idx - 1)
+                                    dec_label = f"{yr}-12"
+                                    if dec_label in years:
+                                        idx_positions.append(years.index(dec_label))
+                                    else:
+                                        yr_periods = [i for i, p in enumerate(years) if str(p).startswith(str(yr))]
+                                        if yr_periods:
+                                            idx_positions.append(yr_periods[-1])
+                                        else:
+                                            idx_positions.append(None)
+                            valid = [(pos, val) for pos, val in zip(idx_positions, vals) if pos is not None]
+                            if valid:
+                                ix, iv = zip(*valid)
+                                ax.plot(list(ix), list(iv), marker=mkr, linestyle=':', linewidth=1.5,
+                                       alpha=0.6, label=label, color=color)
+                        else:
+                            common_len = min(len(years), len(vals))
+                            ax.plot(years[:common_len], vals[:common_len], 
+                                   marker=mkr, linestyle=':', linewidth=1.5, 
+                                   alpha=0.6, label=label, color=color)
             except Exception as e:
                 st.error(f"Error loading extra benchmarks: {e}")
-            # ========================================
-            # ========================================
             
-            ax.set_xlabel('Year', fontsize=12)
             ax.set_ylabel('Portfolio Value ($)', fontsize=12)
             ax.set_title(f'Portfolio Growth: {", ".join(st.session_state.selected_factors)}', fontsize=14, fontweight='bold')
             ax.legend(loc='best')
@@ -716,7 +856,9 @@ def main():
                                 top_pct=cohort_pct,
                                 which='top',
                                 factor_directions=original_dirs,
-                                use_market_cap_weight=st.session_state.use_cap_weight
+                                weighting_method=st.session_state.get('weighting_method', 'Equal Weight'),
+                                target_volatility=st.session_state.get('target_volatility'),
+                                volatility_metric=st.session_state.get('volatility_metric')
                             )
 
                             # 4. Calculate Bottom Cohort (Inverse)
@@ -733,7 +875,9 @@ def main():
                                     top_pct=cohort_pct,
                                     which='bottom',
                                     factor_directions=flipped_dirs,
-                                    use_market_cap_weight=st.session_state.use_cap_weight
+                                    weighting_method=st.session_state.get('weighting_method', 'Equal Weight'),
+                                    target_volatility=st.session_state.get('target_volatility'),
+                                    volatility_metric=st.session_state.get('volatility_metric')
                                 )
 
                             # 5. Helper to extract metric data
@@ -789,11 +933,13 @@ def main():
             
             st.divider()
             
-            # Year-by-year performance table
-            st.subheader("Year-by-Year Performance")
+            # Period-by-period performance table
+            is_sub_annual_table = results.get('data_frequency', 'Yearly') in ['Monthly', 'Daily']
+            period_label = 'Period' if is_sub_annual_table else 'Year'
+            st.subheader(f"{period_label}-by-{period_label} Performance")
             
             perf_data = {
-                'Year': results['years'],
+                period_label: [str(y) for y in results['years']],
                 'Portfolio Value': [f"${v:,.2f}" for v in results['portfolio_values']],
             }
             
@@ -801,19 +947,24 @@ def main():
             if len(results['portfolio_values']) > 1:
                 yoy_returns = ['-']
                 for i in range(1, len(results['portfolio_values'])):
-                    ret = ((results['portfolio_values'][i] / results['portfolio_values'][i-1]) - 1) * 100
-                    yoy_returns.append(f"{ret:.2f}%")
+                    prev = results['portfolio_values'][i-1]
+                    if prev != 0:
+                        ret = ((results['portfolio_values'][i] / prev) - 1) * 100
+                        yoy_returns.append(f"{ret:.2f}%")
+                    else:
+                        yoy_returns.append("N/A")
                 perf_data['YoY Return'] = yoy_returns
             
-            if 'benchmark_returns' in results and results['benchmark_returns']:
-                # Benchmark returns are already in percentage format (like 34.62)
-                perf_data['Benchmark Returns'] = ['-'] + [f"{r:.2f}%" for r in results['benchmark_returns']]
+            if not is_sub_annual_table:
+                if 'benchmark_returns' in results and results['benchmark_returns']:
+                    # Benchmark returns are already in percentage format (like 34.62)
+                    perf_data['Benchmark Returns'] = ['-'] + [f"{r:.2f}%" for r in results['benchmark_returns']]
 
-            if 'growth_benchmark_returns' in results and results['growth_benchmark_returns']:
-                perf_data['Growth Returns'] = ['-'] + [f"{r:.2f}%" for r in results['growth_benchmark_returns']]
+                if 'growth_benchmark_returns' in results and results['growth_benchmark_returns']:
+                    perf_data['Growth Returns'] = ['-'] + [f"{r:.2f}%" for r in results['growth_benchmark_returns']]
 
-            if 'value_benchmark_returns' in results and results['value_benchmark_returns']:
-                perf_data['Value Returns'] = ['-'] + [f"{r:.2f}%" for r in results['value_benchmark_returns']]
+                if 'value_benchmark_returns' in results and results['value_benchmark_returns']:
+                    perf_data['Value Returns'] = ['-'] + [f"{r:.2f}%" for r in results['value_benchmark_returns']]
             
             perf_df = pd.DataFrame(perf_data)
             st.dataframe(perf_df, use_container_width=True, hide_index=True)

--- a/src/calculate_holdings.py
+++ b/src/calculate_holdings.py
@@ -7,7 +7,7 @@ from .factors_doc import FACTOR_DOCS
 from .factor_utils import normalize_series
 from .benchmarks import get_benchmark_list
 
-def calculate_holdings(factor, aum, market, restrict_fossil_fuels=False, top_pct=10, which='top', use_market_cap_weight=False):
+def calculate_holdings(factor, aum, market, restrict_fossil_fuels=False, top_pct=10, which='top', use_market_cap_weight=False, weighting_method='Equal Weight', target_volatility=None, volatility_metric=None):
     # Apply sector restrictions if enabled
     if restrict_fossil_fuels:
         industry_col = 'FactSet Industry'
@@ -69,7 +69,44 @@ def calculate_holdings(factor, aum, market, restrict_fossil_fuels=False, top_pct
     # Calculate number of shares for each selected security
     portfolio_new = Portfolio(name=f"Portfolio_{market.t}")
     
-    if use_market_cap_weight:
+    if weighting_method == 'Volatility Weighted' and volatility_metric:
+        # Inverse-Volatility Weighting (Risk Parity):
+        # Weights are inversely proportional to each stock's expected volatility.
+        # Low-vol stocks get higher allocations. Weights sum to 1.0 (fully invested, no leverage).
+        vols = {}
+        prices = {}
+        for ticker, _ in selected:
+            if volatility_metric in market.stocks.columns:
+                try:
+                    vol = market.stocks.loc[ticker, volatility_metric]
+                    if isinstance(vol, (pd.Series, np.ndarray)):
+                        vol = vol.iloc[0] if len(vol) > 0 else None
+                    if pd.notna(vol) and vol > 0:
+                        vols[ticker] = float(vol)
+                except (KeyError, IndexError):
+                    pass
+            
+            price = market.get_price(ticker)
+            if price is not None and price > 0:
+                prices[ticker] = price
+                
+        valid_vols = {t: v for t, v in vols.items() if t in prices}
+        
+        if valid_vols:
+            # Inverse volatility weights, normalized to sum to 1.0
+            inv_vols = {t: 1.0 / v for t, v in valid_vols.items()}
+            sum_inv_vols = sum(inv_vols.values())
+            weights = {t: iv / sum_inv_vols for t, iv in inv_vols.items()}
+            
+            for ticker, w in weights.items():
+                dollar_investment = w * aum
+                shares = dollar_investment / prices[ticker]
+                portfolio_new.add_investment(ticker, shares)
+        else:
+            print(f"Warning: No valid volatility data for year {market.t}; falling back to Equal Weight.")
+            _apply_equal_weight(portfolio_new, selected, aum, market)
+
+    elif use_market_cap_weight or weighting_method == 'Market Cap Weight':
         # Market capitalization-based weighting (similar to Russell 2000)
         # Collect market cap and price for each selected ticker, then allocate
         market_caps = {}
@@ -111,29 +148,25 @@ def calculate_holdings(factor, aum, market, restrict_fossil_fuels=False, top_pct
                     portfolio_new.add_investment(t, shares)
         else:
             # Fallback to equal weighting among tickers that have valid prices
-            valid_tickers = [t for t, _ in selected if market.get_price(t) is not None and market.get_price(t) > 0]
-            if not valid_tickers:
-                print(f"Warning: No valid priced tickers for year {market.t}; returning empty portfolio.")
-            else:
-                equal_investment = aum / len(valid_tickers)
-                for ticker in valid_tickers:
-                    price = market.get_price(ticker)
-                    if price is not None and price > 0:
-                        shares = equal_investment / price
-                        portfolio_new.add_investment(ticker, shares)
+            print(f"Warning: No valid market caps for year {market.t}; falling back to Equal Weight.")
+            _apply_equal_weight(portfolio_new, selected, aum, market)
     else:
-        # Equal dollar weighting (allocate only to tickers with valid entry prices)
-        valid_tickers = [t for t, _ in selected if market.get_price(t) is not None and market.get_price(t) > 0]
-        if not valid_tickers and selected:
-            # nothing priced; warn and return empty portfolio
-            print(f"Warning: No valid priced tickers for equal-weighting in year {market.t}; returning empty portfolio.")
-        else:
-            equal_investment = aum / len(valid_tickers) if valid_tickers else 0
-            for ticker in valid_tickers:
-                price = market.get_price(ticker)
-                if price is not None and price > 0:
-                    shares = equal_investment / price
-                    portfolio_new.add_investment(ticker, shares)
+        # Equal dollar weighting
+        _apply_equal_weight(portfolio_new, selected, aum, market)
+
+    return portfolio_new
+
+def _apply_equal_weight(portfolio_new, selected, aum, market):
+    valid_tickers = [t for t, _ in selected if market.get_price(t) is not None and market.get_price(t) > 0]
+    if not valid_tickers and selected:
+        print(f"Warning: No valid priced tickers for equal-weighting in year {market.t}; returning empty portfolio.")
+    else:
+        equal_investment = aum / len(valid_tickers) if valid_tickers else 0
+        for ticker in valid_tickers:
+            price = market.get_price(ticker)
+            if price is not None and price > 0:
+                shares = equal_investment / price
+                portfolio_new.add_investment(ticker, shares)
 
     return portfolio_new
 
@@ -151,7 +184,11 @@ def calculate_growth(portfolio, current_market, verbosity=0):
             # Retrieve the pre-calculated total return from the current market object
             try:
                 # Dividing by 100 because the data is in percentage format (e.g., 20.0 for 20%)
-                stock_rtn = current_market.stocks.loc[ticker, "Next_Year_Return"] / 100
+                raw_rtn = current_market.stocks.loc[ticker, "Next_Year_Return"]
+                # Handle duplicate index entries: extract scalar first
+                if isinstance(raw_rtn, (pd.Series, pd.DataFrame)):
+                    raw_rtn = raw_rtn.iloc[0]
+                stock_rtn = float(raw_rtn) / 100
                 
                 # Weight the return by the dollar value of the position at the start of the year
                 entry_price = current_market.get_price(ticker)
@@ -173,27 +210,40 @@ def calculate_growth(portfolio, current_market, verbosity=0):
     
     return growth, total_investment_value, total_end_value
 
-def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, benchmark_index=1, verbosity=0, restrict_fossil_fuels=False, top_pct=10, which='top', use_market_cap_weight=False, factor_directions=None):
+def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, benchmark_index=1, verbosity=0, restrict_fossil_fuels=False, top_pct=10, which='top', use_market_cap_weight=False, factor_directions=None, weighting_method='Equal Weight', target_volatility=None, volatility_metric=None, data_frequency='Yearly', rebalance_frequency=None):
     """
-    Executes a multi-year backtest. 
-    Calculates Sharpe and Beta using year-specific excess returns.
+    Executes a multi-period backtest. 
+    Calculates Sharpe and Beta using period-specific excess returns.
+    
+    For 'Yearly' data_frequency, rebalances annually (legacy behavior).
+    For 'Monthly'/'Daily', rebalances each period using the Period column.
+    
+    rebalance_frequency controls how often the portfolio is reconstructed.
+    Between rebalances, existing holdings compound returns at data granularity.
 
     Args:
         factor_directions: optional dict mapping factor column_name -> 'top'/'bottom'.
-            When provided, overrides the global ``which`` on a per-factor basis.
+        data_frequency: 'Yearly', 'Monthly', or 'Daily'
+        rebalance_frequency: 'Daily', 'Monthly', 'Quarterly', 'Yearly', or None (same as data)
     """
     aum = initial_aum
-    years = [start_year]
     portfolio_returns = []  
     portfolio_values = [aum]  
+    periods = []
     
     verbosity = 0 if verbosity is None else verbosity
     risk_free_rate_source = "FRED 4 Week T-Bill (Oct 1)"
+    
+    is_sub_annual = data_frequency in ['Monthly', 'Daily']
+    
+    # Default rebalance_frequency to match data_frequency
+    if rebalance_frequency is None:
+        rebalance_frequency = data_frequency
 
-    # --- 1. Annual Rebalancing Loop ---
-    for year in range(start_year, end_year):
-        market = MarketObject(data.loc[data['Year'] == year], year)
-        yearly_portfolio = []
+    def _build_portfolio(period_data, period_label):
+        """Construct portfolio from factor scores (no growth applied)."""
+        market = MarketObject(period_data, period_label)
+        period_portfolio = []
 
         for factor in factors:
             factor_which = which
@@ -208,85 +258,228 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, benchm
                 restrict_fossil_fuels=restrict_fossil_fuels,
                 top_pct=top_pct,
                 which=factor_which,
-                use_market_cap_weight=use_market_cap_weight
+                use_market_cap_weight=use_market_cap_weight,
+                weighting_method=weighting_method,
+                target_volatility=target_volatility,
+                volatility_metric=volatility_metric
             )
-            yearly_portfolio.append(factor_portfolio)
+            period_portfolio.append(factor_portfolio)
 
-        # Calculate annual growth
-        growth, total_start_value, total_end_value = calculate_growth(yearly_portfolio, market, verbosity)
+        return period_portfolio
+    
+    def _apply_growth(portfolio_list, period_data, period_label):
+        """Apply one period's returns to an existing portfolio."""
+        nonlocal aum
+        market = MarketObject(period_data, period_label)
+        growth, total_start_value, total_end_value = calculate_growth(portfolio_list, market, verbosity)
 
         if verbosity >= 2:
-            print(f"Year {year} to {year + 1}: Growth: {growth:.2%}, Start: ${total_start_value:.2f}, End: ${total_end_value:.2f}")
+            print(f"Period {period_label}: Growth: {growth:.2%}, Start: ${total_start_value:.2f}, End: ${total_end_value:.2f}")
 
-        aum = total_end_value  
+        aum = total_end_value if total_end_value > 0 else aum
         portfolio_returns.append(growth)
         portfolio_values.append(aum)
-        years.append(year + 1)
 
+    def _build_and_grow(period_data, period_label):
+        """Run portfolio construction and growth for one period (legacy single-step)."""
+        portfolio_list = _build_portfolio(period_data, period_label)
+        _apply_growth(portfolio_list, period_data, period_label)
+
+    def _get_rebalance_key(period_str, rebal_freq):
+        """Map a period label to its rebalance window key."""
+        if rebal_freq == 'Daily':
+            return period_str  # rebalance every period
+        elif rebal_freq == 'Monthly':
+            # Daily "2020-01-15" -> "2020-01", Monthly "2020-01" -> "2020-01"
+            return period_str[:7]
+        elif rebal_freq == 'Quarterly':
+            # Map month to quarter: Jan-Mar -> Q1, Apr-Jun -> Q2, etc.
+            month = int(period_str[5:7])
+            quarter = (month - 1) // 3 + 1
+            return f"{period_str[:4]}-Q{quarter}"
+        elif rebal_freq == 'Yearly':
+            return period_str[:4]
+        return period_str
+    
+    # --- 1. Rebalancing Loop ---
+    if is_sub_annual and 'Period' in data.columns:
+        sorted_periods = sorted(data['Period'].unique())
+        if not sorted_periods:
+            periods = [f"{start_year}-01"]
+        else:
+            periods = [sorted_periods[0]]  # Starting label
+            
+            current_portfolio = None
+            last_rebal_key = None
+            
+            for period in sorted_periods:
+                period_data = data.loc[data['Period'] == period]
+                if period_data.empty:
+                    portfolio_returns.append(0.0)
+                    portfolio_values.append(aum)
+                    periods.append(period)
+                    continue
+                
+                rebal_key = _get_rebalance_key(period, rebalance_frequency)
+                
+                if rebal_key != last_rebal_key:
+                    # --- REBALANCE POINT: reconstruct portfolio AND apply growth ---
+                    current_portfolio = _build_portfolio(period_data, period)
+                    _apply_growth(current_portfolio, period_data, period)
+                    last_rebal_key = rebal_key
+                else:
+                    # --- HOLD: apply growth to existing portfolio ---
+                    _apply_growth(current_portfolio, period_data, period)
+                
+                periods.append(period)
+    else:
+        # Annual: legacy behavior
+        periods = [start_year]
+        for year in range(start_year, end_year):
+            year_data = data.loc[data['Year'] == year]
+            
+            if year_data.empty:
+                portfolio_returns.append(0.0)
+                portfolio_values.append(aum)
+                periods.append(year + 1)
+                if verbosity >= 1:
+                    print(f"Year {year}: No data available, carrying forward AUM ${aum:,.2f}")
+                continue
+            
+            _build_and_grow(year_data, year)
+            periods.append(year + 1)
+
+    # Backward-compatible alias
+    years = periods
+    
     # --- 2. Data Alignment (Benchmarks & Risk-Free) ---
-    # Fetched from benchmarks.py to ensure data integrity across the range
-    rf_list = get_benchmark_list(4, start_year, end_year)
-    bench_list = get_benchmark_list(benchmark_index, start_year + 1, end_year + 1)
-    growth_bench_list = get_benchmark_list(2, start_year + 1, end_year + 1)
-    value_bench_list = get_benchmark_list(3, start_year + 1, end_year + 1)
+    # Always fetch yearly benchmark data for stats and chart overlays
+    if is_sub_annual:
+        rf_list = get_benchmark_list(4, start_year, end_year + 1)
+        bench_list = get_benchmark_list(benchmark_index, start_year, end_year + 1)
+        growth_bench_list = get_benchmark_list(2, start_year, end_year + 1)
+        value_bench_list = get_benchmark_list(3, start_year, end_year + 1)
+    else:
+        # Annual rebalancing is forward-looking (realizes return in year+1)
+        rf_list = get_benchmark_list(4, start_year, end_year)
+        bench_list = get_benchmark_list(benchmark_index, start_year + 1, end_year + 1)
+        growth_bench_list = get_benchmark_list(2, start_year + 1, end_year + 1)
+        value_bench_list = get_benchmark_list(3, start_year + 1, end_year + 1)
 
-    # Convert to NumPy for performance math
     portfolio_returns_np = np.array(portfolio_returns)
-    rf_rates_np = np.array(rf_list)
-    benchmark_returns_np = np.array(bench_list) / 100 
+    benchmark_returns_np = np.array(bench_list) / 100
     growth_returns_np = np.array(growth_bench_list) / 100
     value_returns_np = np.array(value_bench_list) / 100
+    rf_rates_yearly_np = np.array(rf_list)
 
-    # Full-sample volatility of RAW returns
-    vol_raw_portfolio = np.std(portfolio_returns_np, ddof=1)
-    vol_raw_benchmark = np.std(benchmark_returns_np, ddof=1)
-    vol_raw_growth = np.std(growth_returns_np, ddof=1)
-    vol_raw_value = np.std(value_returns_np, ddof=1)
+    # Annualize Volatility if sub-annual (for apples-to-apples comparison with yearly benchmarks)
+    annual_factor = 1
+    if is_sub_annual:
+        annual_factor = 12 if data_frequency == 'Monthly' else 252
+
+    vol_raw_portfolio = np.std(portfolio_returns_np, ddof=1) * np.sqrt(annual_factor) if len(portfolio_returns_np) > 1 else 0
+    vol_raw_benchmark = np.std(benchmark_returns_np, ddof=1) if len(benchmark_returns_np) > 1 else 0
+    vol_raw_growth = np.std(growth_returns_np, ddof=1) if len(growth_returns_np) > 1 else 0
+    vol_raw_value = np.std(value_returns_np, ddof=1) if len(value_returns_np) > 1 else 0
     
 # --- 3. Excess Return Calculations ---
-    excess_portfolio_returns = portfolio_returns_np - rf_rates_np
-    excess_benchmark_returns = benchmark_returns_np - rf_rates_np
-    excess_growth_returns = growth_returns_np - rf_rates_np
-    excess_value_returns = value_returns_np - rf_rates_np
+    # Portfolio excess returns: use rf=0 for sub-annual (no monthly rf available)
+    if is_sub_annual:
+        excess_portfolio_returns = portfolio_returns_np  # rf=0
+    else:
+        excess_portfolio_returns = portfolio_returns_np - rf_rates_yearly_np
     
-    # --- 4. Sharpe Ratio ---
-    # Volatility of the EXCESS returns (Institutional Standard)
-    vol_excess_p = np.std(excess_portfolio_returns, ddof=1)
-    vol_excess_b = np.std(excess_benchmark_returns, ddof=1)
-    vol_excess_growth = np.std(excess_growth_returns, ddof=1)
-    vol_excess_value = np.std(excess_value_returns, ddof=1)
+    # Benchmark excess returns: always yearly
+    excess_benchmark_returns = benchmark_returns_np - rf_rates_yearly_np
+    excess_growth_returns = growth_returns_np - rf_rates_yearly_np
+    excess_value_returns = value_returns_np - rf_rates_yearly_np
+    
+    vol_excess_p = np.std(excess_portfolio_returns, ddof=1) * np.sqrt(annual_factor) if len(excess_portfolio_returns) > 1 else 0
+    vol_excess_b = np.std(excess_benchmark_returns, ddof=1) if len(excess_benchmark_returns) > 1 else 0
+    vol_excess_growth = np.std(excess_growth_returns, ddof=1) if len(excess_growth_returns) > 1 else 0
+    vol_excess_value = np.std(excess_value_returns, ddof=1) if len(excess_value_returns) > 1 else 0
 
-    # Formula: Mean(Yearly Excess Returns) / Volatility(Yearly Excess Returns)
-    sharpe_portfolio = np.mean(excess_portfolio_returns) / vol_excess_p if vol_excess_p > 0 else 0
+    std_excess_p_unscaled = vol_excess_p / np.sqrt(annual_factor) if vol_excess_p > 0 else 0
+    # Use portfolio value-based CAGR for Sharpe (matches the displayed CAGR exactly)
+    # This is robust against data loading issues that cause period count mismatches
+    if is_sub_annual and vol_excess_p > 0 and len(portfolio_values) > 1:
+        calendar_years = max(end_year - start_year + 1, 1)  # Inclusive: 2020-2024 = 5 years
+        total_growth = portfolio_values[-1] / portfolio_values[0]
+        cagr_return = total_growth ** (1.0 / calendar_years) - 1 if total_growth > 0 else 0
+        sharpe_portfolio = cagr_return / vol_excess_p if vol_excess_p > 0 else 0
+    else:
+        sharpe_portfolio = (np.mean(excess_portfolio_returns) / std_excess_p_unscaled) * np.sqrt(annual_factor) if std_excess_p_unscaled > 0 else 0
     sharpe_benchmark = np.mean(excess_benchmark_returns) / vol_excess_b if vol_excess_b > 0 else 0
     sharpe_growth = np.mean(excess_growth_returns) / vol_excess_growth if vol_excess_growth > 0 else 0
     sharpe_value = np.mean(excess_value_returns) / vol_excess_value if vol_excess_value > 0 else 0
     
-    # --- 5. Portfolio Beta ---
     portfolio_beta = None
     portfolio_beta_growth = None
     portfolio_beta_value = None
-    if len(portfolio_returns_np) >= 3:
-        # CAPM Beta using excess returns
+    information_ratio = None
+    information_ratio_growth = None
+    information_ratio_value = None
+    
+    if is_sub_annual and len(portfolio_returns_np) >= 3:
+        # Aggregate daily/monthly portfolio returns to yearly for beta/IR calculation
+        # periods list has the period labels (e.g. "2020-01-02", "2020-03-15")
+        period_labels = periods[1:] if len(periods) > len(portfolio_returns_np) else periods
+        yearly_pf_returns = {}
+        for i, ret in enumerate(portfolio_returns_np):
+            if i < len(period_labels):
+                year_key = str(period_labels[i])[:4]
+                if year_key not in yearly_pf_returns:
+                    yearly_pf_returns[year_key] = 1.0
+                yearly_pf_returns[year_key] *= (1 + ret)
+        
+        # Convert compounded values to returns
+        yearly_pf_list = [(y, v - 1) for y, v in sorted(yearly_pf_returns.items())]
+        yearly_pf_np = np.array([r for _, r in yearly_pf_list])
+        
+        # Align with benchmark returns (both should be yearly now)
+        n_common = min(len(yearly_pf_np), len(excess_benchmark_returns))
+        if n_common >= 3:
+            yr_pf = yearly_pf_np[:n_common]
+            yr_bench = excess_benchmark_returns[:n_common]
+            yr_growth = excess_growth_returns[:n_common]
+            yr_value = excess_value_returns[:n_common]
+            yr_rf = rf_rates_yearly_np[:n_common] if len(rf_rates_yearly_np) >= n_common else np.zeros(n_common)
+            yr_pf_excess = yr_pf - yr_rf
+            
+            coeffs = np.polyfit(yr_bench, yr_pf_excess, 1)
+            portfolio_beta = float(coeffs[0])
+            growth_coeffs = np.polyfit(yr_growth, yr_pf_excess, 1)
+            portfolio_beta_growth = float(growth_coeffs[0])
+            value_coeffs = np.polyfit(yr_value, yr_pf_excess, 1)
+            portfolio_beta_value = float(value_coeffs[0])
+            
+            information_ratio = (np.mean(yr_pf_excess - yr_bench) /
+                                 np.std(yr_pf_excess - yr_bench, ddof=1)) if np.std(yr_pf_excess - yr_bench, ddof=1) > 0 else 0
+            information_ratio_growth = (np.mean(yr_pf_excess - yr_growth) /
+                                       np.std(yr_pf_excess - yr_growth, ddof=1)) if np.std(yr_pf_excess - yr_growth, ddof=1) > 0 else 0
+            information_ratio_value = (np.mean(yr_pf_excess - yr_value) /
+                                      np.std(yr_pf_excess - yr_value, ddof=1)) if np.std(yr_pf_excess - yr_value, ddof=1) > 0 else 0
+    
+    elif not is_sub_annual and len(portfolio_returns_np) >= 3:
         coeffs = np.polyfit(excess_benchmark_returns, excess_portfolio_returns, 1)
         portfolio_beta = float(coeffs[0])
         growth_coeffs = np.polyfit(excess_growth_returns, excess_portfolio_returns, 1)
         portfolio_beta_growth = float(growth_coeffs[0])
         value_coeffs = np.polyfit(excess_value_returns, excess_portfolio_returns, 1)
         portfolio_beta_value = float(value_coeffs[0])
-
-    # --- 6. Additional Risk Metrics ---
-    # Information Ratio
-    information_ratio = calculate_information_ratio(portfolio_returns, bench_list, verbosity)
-    information_ratio_growth = calculate_information_ratio(portfolio_returns, growth_bench_list, verbosity)
-    information_ratio_value = calculate_information_ratio(portfolio_returns, value_bench_list, verbosity)
+        
+        information_ratio = (np.mean(excess_portfolio_returns - excess_benchmark_returns) / 
+                             np.std(excess_portfolio_returns - excess_benchmark_returns, ddof=1)) if np.std(excess_portfolio_returns - excess_benchmark_returns, ddof=1) > 0 else 0
+        information_ratio_growth = (np.mean(excess_portfolio_returns - excess_growth_returns) / 
+                                   np.std(excess_portfolio_returns - excess_growth_returns, ddof=1)) if np.std(excess_portfolio_returns - excess_growth_returns, ddof=1) > 0 else 0
+        information_ratio_value = (np.mean(excess_portfolio_returns - excess_value_returns) / 
+                                  np.std(excess_portfolio_returns - excess_value_returns, ddof=1)) if np.std(excess_portfolio_returns - excess_value_returns, ddof=1) > 0 else 0
     
-    # Portfolio Max Drawdown
     cumulative_values = np.array(portfolio_values)
     running_peak = np.maximum.accumulate(cumulative_values)
-    max_drawdown_portfolio = np.min((cumulative_values - running_peak) / running_peak)
+    max_drawdown_portfolio = np.min((cumulative_values - running_peak) / running_peak) if len(running_peak) > 0 else 0
     
-    # Benchmark Max Drawdown
+    # Always compute benchmark drawdowns from yearly data
     benchmark_cumulative = [initial_aum]
     growth_cumulative = [initial_aum]
     value_cumulative = [initial_aum]
@@ -309,14 +502,32 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, benchm
     value_peak = np.maximum.accumulate(value_cumulative_np)
     max_drawdown_value = np.min((value_cumulative_np - value_peak) / value_peak)
 
-    # Yearly Win Rate
+    # Compute actual realized yearly portfolio returns for realistic win-rate comparisons
+    yearly_portfolio_returns = []
+    if is_sub_annual:
+        last_val = initial_aum
+        for yr in range(start_year, end_year + 1):
+            yr_str = str(yr)
+            yr_indices = [i for i, p in enumerate(periods) if str(p).startswith(yr_str)]
+            if yr_indices:
+                end_idx = yr_indices[-1]
+                val = portfolio_values[end_idx]
+                yearly_ret = (val / last_val) - 1
+                yearly_portfolio_returns.append(yearly_ret)
+                last_val = val
+            elif yr <= end_year:
+                yearly_portfolio_returns.append(0.0)
+    else:
+        yearly_portfolio_returns = portfolio_returns_np.tolist()
+
     wins = 0
     yearly_comparisons = []
-    for i, (p_ret, b_ret, g_ret, v_ret) in enumerate(zip(portfolio_returns_np, benchmark_returns_np, growth_returns_np, value_returns_np)):
+    for i, (p_ret, b_ret, g_ret, v_ret) in enumerate(zip(yearly_portfolio_returns, benchmark_returns_np, growth_returns_np, value_returns_np)):
         win = p_ret > b_ret
         if win: wins += 1
+        yr_label = start_year + i
         yearly_comparisons.append({
-            'year': years[i+1],
+            'year': yr_label,
             'portfolio_return': p_ret * 100,
             'benchmark_return': b_ret * 100,
             'win': win,
@@ -325,47 +536,21 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, benchm
             'value_return': v_ret * 100,
             'value_win': p_ret > v_ret
         })
-    win_rate = wins / len(portfolio_returns_np) if len(portfolio_returns_np) > 0 else 0
+    win_rate = wins / len(yearly_portfolio_returns) if len(yearly_portfolio_returns) > 0 else 0
 
     wins_growth = 0
     wins_value = 0
-    for p_ret, g_ret, v_ret in zip(portfolio_returns_np, growth_returns_np, value_returns_np):
-        if p_ret > g_ret:
-            wins_growth += 1
-        if p_ret > v_ret:
-            wins_value += 1
-    win_rate_growth = wins_growth / len(portfolio_returns_np) if len(portfolio_returns_np) > 0 else 0
-    win_rate_value = wins_value / len(portfolio_returns_np) if len(portfolio_returns_np) > 0 else 0
+    for p_ret, g_ret, v_ret in zip(yearly_portfolio_returns, growth_returns_np, value_returns_np):
+        if p_ret > g_ret: wins_growth += 1
+        if p_ret > v_ret: wins_value += 1
+    win_rate_growth = wins_growth / len(yearly_portfolio_returns) if len(yearly_portfolio_returns) > 0 else 0
+    win_rate_value = wins_value / len(yearly_portfolio_returns) if len(yearly_portfolio_returns) > 0 else 0
 
-    # --- 7. Summary Output ---
     if verbosity >= 1:
         print(f"\n==== Performance Metrics ({start_year}-{end_year}) ====")
         print(f"Final AUM: ${aum:.2f}")
-        print(f"Volatility (Raw Returns, Portfolio): {vol_raw_portfolio:.4%}")
-        print(f"Volatility (Raw Returns, Benchmark): {vol_raw_benchmark:.4%}")
-        print(f"Volatility (Raw Returns, Growth Index): {vol_raw_growth:.4%}")
-        print(f"Volatility (Raw Returns, Value Index): {vol_raw_value:.4%}")
-        print(f"Volatility (Excess Returns, Portfolio): {vol_excess_p:.4%}")
-        print(f"Volatility (Excess Returns, Benchmark): {vol_excess_b:.4%}")
-        print(f"Volatility (Excess Returns, Growth Index): {vol_excess_growth:.4%}")
-        print(f"Volatility (Excess Returns, Value Index): {vol_excess_value:.4%}")
         print(f"Sharpe Ratio (Portfolio): {sharpe_portfolio:.4f}")
-        print(f"Sharpe Ratio (Benchmark): {sharpe_benchmark:.4f}")
-        print(f"Sharpe Ratio (Growth Index): {sharpe_growth:.4f}")
-        print(f"Sharpe Ratio (Value Index): {sharpe_value:.4f}")
-        if portfolio_beta is not None:
-            print(f"Portfolio Beta: {portfolio_beta:.4f}")
-        if portfolio_beta_growth is not None:
-            print(f"Beta (Portfolio vs Growth Index): {portfolio_beta_growth:.4f}")
-        if portfolio_beta_value is not None:
-            print(f"Beta (Portfolio vs Value Index): {portfolio_beta_value:.4f}")
         print(f"Max Drawdown (Portfolio): {max_drawdown_portfolio:.2%}")
-        print(f"Max Drawdown (Benchmark): {max_drawdown_benchmark:.2%}")
-        print(f"Max Drawdown (Growth Index): {max_drawdown_growth:.2%}")
-        print(f"Max Drawdown (Value Index): {max_drawdown_value:.2%}")
-        print(f"Win Rate: {win_rate:.2%}")
-        print(f"Win Rate (vs Growth Index): {win_rate_growth:.2%}")
-        print(f"Win Rate (vs Value Index): {win_rate_value:.2%}")
 
     return {
         'final_value': aum,
@@ -401,7 +586,8 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, benchm
         'yearly_comparisons': yearly_comparisons,
         'information_ratio': information_ratio,
         'information_ratio_growth': information_ratio_growth,
-        'information_ratio_value': information_ratio_value
+        'information_ratio_value': information_ratio_value,
+        'data_frequency': data_frequency
     }
 def calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity=0):
     """

--- a/src/calculate_holdings.py
+++ b/src/calculate_holdings.py
@@ -226,6 +226,16 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, benchm
         data_frequency: 'Yearly', 'Monthly', or 'Daily'
         rebalance_frequency: 'Daily', 'Monthly', 'Quarterly', 'Yearly', or None (same as data)
     """
+    
+    # 100% Legacy fallback for Yearly frequency
+    if data_frequency == 'Yearly':
+        return _rebalance_portfolio_yearly(
+            data=data, factors=factors, start_year=start_year, end_year=end_year, 
+            initial_aum=initial_aum, benchmark_index=benchmark_index, verbosity=verbosity, 
+            restrict_fossil_fuels=restrict_fossil_fuels, top_pct=top_pct, which=which, 
+            use_market_cap_weight=use_market_cap_weight, factor_directions=factor_directions
+        )
+
     aum = initial_aum
     portfolio_returns = []  
     portfolio_values = [aum]  
@@ -624,3 +634,401 @@ def calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity=
     if verbosity >=1:
         print(f"Information Ratio: {information_ratio:.4f}")
     return information_ratio
+
+
+def _calculate_holdings_yearly(factor, aum, market, restrict_fossil_fuels=False, top_pct=10, which='top', use_market_cap_weight=False):
+    # Apply sector restrictions if enabled
+    if restrict_fossil_fuels:
+        industry_col = 'FactSet Industry'
+        if industry_col in market.stocks.columns:
+            fossil_keywords = ['oil', 'gas', 'coal', 'energy', 'fossil']
+            series = market.stocks[industry_col].astype(str).str.lower()
+            mask = series.apply(
+                lambda x: not any(kw in x for kw in fossil_keywords) if pd.notna(x) else True)
+            # Report which tickers are being removed in this step
+            try:
+                removed_tickers = list(market.stocks.loc[~mask].index)
+                if removed_tickers:
+                    print(f"Fossil filter (holdings) removed {len(removed_tickers)} tickers: {', '.join(removed_tickers[:25])}{' ...' if len(removed_tickers) > 25 else ''}")
+            except Exception:
+                pass
+            market.stocks = market.stocks[mask].copy()
+
+    # Get eligible stocks for factor calculation
+    # Prefer vectorized series from market.stocks when available so we can normalize
+    factor_col = getattr(factor, 'column_name', str(factor))
+    factor_values = {}
+
+    if factor_col in market.stocks.columns:
+        raw_series = pd.to_numeric(market.stocks[factor_col], errors='coerce')
+        # Determine direction from FACTOR_DOCS if available
+        meta = FACTOR_DOCS.get(factor_col, {})
+        higher_is_better = meta.get('higher_is_better', True)
+        # Normalize series (winsorize + zscore) and invert if needed so higher == better
+        normed = normalize_series(raw_series, higher_is_better=higher_is_better)
+        factor_values = normed.dropna().to_dict()
+    else:
+        # Fallback to original per-ticker get() when column not present
+        factor_values = {
+            ticker: factor.get(ticker, market)
+            for ticker in market.stocks.index
+            if isinstance(factor.get(ticker, market), (int, float))
+        }
+    
+    # ...existing code...
+    
+    if len(factor_values) == 0:
+        # Return empty portfolio instead of crashing
+        return Portfolio(name=f"Portfolio_{market.t}")
+    
+    sorted_securities = sorted(factor_values.items(), key=lambda x: x[1], reverse=True)
+
+    # Select the top or bottom `top_pct`% of securities (default 10%)
+    import math
+    n_select = max(1, math.floor(len(sorted_securities) * (top_pct / 100.0))) if sorted_securities else 0
+    if n_select == 0:
+        selected = []
+    else:
+        if which == 'top':
+            selected = sorted_securities[:n_select]
+        else:
+            # bottom: take the weakest n_select securities
+            selected = sorted_securities[-n_select:]
+
+    # Calculate number of shares for each selected security
+    portfolio_new = Portfolio(name=f"Portfolio_{market.t}")
+    
+    if use_market_cap_weight:
+        # Market capitalization-based weighting (similar to Russell 2000)
+        # Collect market cap and price for each selected ticker, then allocate
+        market_caps = {}
+        prices = {}
+        for ticker, _ in selected:
+            # Try to get market cap from the data
+            if 'Market Capitalization' in market.stocks.columns:
+                try:
+                    market_cap = market.stocks.loc[ticker, 'Market Capitalization']
+                    if isinstance(market_cap, (pd.Series, np.ndarray)):
+                        market_cap = market_cap.iloc[0] if len(market_cap) > 0 else None
+                    if pd.notna(market_cap) and market_cap > 0:
+                        market_caps[ticker] = float(market_cap)
+                except (KeyError, IndexError):
+                    pass
+            # also capture entry price availability
+            price = market.get_price(ticker)
+            if price is not None and price > 0:
+                prices[ticker] = price
+
+        # If we have market caps and at least one valid price, use them for weighting
+        valid_caps = {t: c for t, c in market_caps.items() if t in prices}
+        if valid_caps:
+            total_market_cap = sum(valid_caps.values())
+            for ticker, cap in valid_caps.items():
+                # Weight by market cap: (ticker_market_cap / total_market_cap) * AUM
+                weight = cap / total_market_cap if total_market_cap > 0 else 0
+                dollar_investment = weight * aum
+                price = prices.get(ticker)
+                if price is not None and price > 0 and dollar_investment > 0:
+                    shares = dollar_investment / price
+                    portfolio_new.add_investment(ticker, shares)
+            # If for some reason no shares were added (e.g., rounding), fallback to equal among priced tickers
+            if not portfolio_new.investments and prices:
+                valid_tickers = list(prices.keys())
+                equal_investment = aum / len(valid_tickers)
+                for t in valid_tickers:
+                    shares = equal_investment / prices[t]
+                    portfolio_new.add_investment(t, shares)
+        else:
+            # Fallback to equal weighting among tickers that have valid prices
+            valid_tickers = [t for t, _ in selected if market.get_price(t) is not None and market.get_price(t) > 0]
+            if not valid_tickers:
+                print(f"Warning: No valid priced tickers for year {market.t}; returning empty portfolio.")
+            else:
+                equal_investment = aum / len(valid_tickers)
+                for ticker in valid_tickers:
+                    price = market.get_price(ticker)
+                    if price is not None and price > 0:
+                        shares = equal_investment / price
+                        portfolio_new.add_investment(ticker, shares)
+    else:
+        # Equal dollar weighting (allocate only to tickers with valid entry prices)
+        valid_tickers = [t for t, _ in selected if market.get_price(t) is not None and market.get_price(t) > 0]
+        if not valid_tickers and selected:
+            # nothing priced; warn and return empty portfolio
+            print(f"Warning: No valid priced tickers for equal-weighting in year {market.t}; returning empty portfolio.")
+        else:
+            equal_investment = aum / len(valid_tickers) if valid_tickers else 0
+            for ticker in valid_tickers:
+                price = market.get_price(ticker)
+                if price is not None and price > 0:
+                    shares = equal_investment / price
+                    portfolio_new.add_investment(ticker, shares)
+
+    return portfolio_new
+
+def _calculate_growth_yearly(portfolio, current_market, verbosity=0):
+    """
+    Calculates portfolio growth using the forward-looking 'Next_Year_Return' column.
+    """
+    total_weighted_rtn = 0
+    total_investment_value = 0
+
+    for factor_portfolio in portfolio:
+        for inv in factor_portfolio.investments:
+            ticker = inv["ticker"]
+            
+            # Retrieve the pre-calculated total return from the current market object
+            try:
+                # Dividing by 100 because the data is in percentage format (e.g., 20.0 for 20%)
+                stock_rtn = current_market.stocks.loc[ticker, "Next_Year_Return"] / 100
+                
+                # Weight the return by the dollar value of the position at the start of the year
+                entry_price = current_market.get_price(ticker)
+                if entry_price:
+                    position_value = inv["number_of_shares"] * entry_price
+                    total_weighted_rtn += stock_rtn * position_value
+                    total_investment_value += position_value
+                    
+            except KeyError:
+                if verbosity >= 2:
+                    print(f"Warning: {ticker} return data missing, treating as 0%.")
+                continue
+
+    # Calculate aggregate growth for the year
+    growth = total_weighted_rtn / total_investment_value if total_investment_value > 0 else 0
+    
+    # Calculate end value to maintain compatibility with the rebalancing loop
+    total_end_value = total_investment_value * (1 + growth)
+    
+    return growth, total_investment_value, total_end_value
+
+def _rebalance_portfolio_yearly(data, factors, start_year, end_year, initial_aum, benchmark_index=1, verbosity=0, restrict_fossil_fuels=False, top_pct=10, which='top', use_market_cap_weight=False, factor_directions=None):
+    """
+    Executes a multi-year backtest. 
+    Calculates Sharpe and Beta using year-specific excess returns.
+
+    Args:
+        factor_directions: optional dict mapping factor column_name -> 'top'/'bottom'.
+            When provided, overrides the global ``which`` on a per-factor basis.
+    """
+    aum = initial_aum
+    years = [start_year]
+    portfolio_returns = []  
+    portfolio_values = [aum]  
+    
+    verbosity = 0 if verbosity is None else verbosity
+    risk_free_rate_source = "FRED 4 Week T-Bill (Oct 1)"
+
+    # --- 1. Annual Rebalancing Loop ---
+    for year in range(start_year, end_year):
+        market = MarketObject(data.loc[data['Year'] == year], year)
+        yearly_portfolio = []
+
+        for factor in factors:
+            factor_which = which
+            if factor_directions:
+                col_name = getattr(factor, 'column_name', str(factor))
+                factor_which = factor_directions.get(col_name, which)
+
+            factor_portfolio = _calculate_holdings_yearly(
+                factor=factor,
+                aum=aum / len(factors),
+                market=market,
+                restrict_fossil_fuels=restrict_fossil_fuels,
+                top_pct=top_pct,
+                which=factor_which,
+                use_market_cap_weight=use_market_cap_weight
+            )
+            yearly_portfolio.append(factor_portfolio)
+
+        # Calculate annual growth
+        growth, total_start_value, total_end_value = _calculate_growth_yearly(yearly_portfolio, market, verbosity)
+
+        if verbosity >= 2:
+            print(f"Year {year} to {year + 1}: Growth: {growth:.2%}, Start: ${total_start_value:.2f}, End: ${total_end_value:.2f}")
+
+        aum = total_end_value  
+        portfolio_returns.append(growth)
+        portfolio_values.append(aum)
+        years.append(year + 1)
+
+    # --- 2. Data Alignment (Benchmarks & Risk-Free) ---
+    # Fetched from benchmarks.py to ensure data integrity across the range
+    rf_list = get_benchmark_list(4, start_year, end_year)
+    bench_list = get_benchmark_list(benchmark_index, start_year + 1, end_year + 1)
+    growth_bench_list = get_benchmark_list(2, start_year + 1, end_year + 1)
+    value_bench_list = get_benchmark_list(3, start_year + 1, end_year + 1)
+
+    # Convert to NumPy for performance math
+    portfolio_returns_np = np.array(portfolio_returns)
+    rf_rates_np = np.array(rf_list)
+    benchmark_returns_np = np.array(bench_list) / 100 
+    growth_returns_np = np.array(growth_bench_list) / 100
+    value_returns_np = np.array(value_bench_list) / 100
+
+    # Full-sample volatility of RAW returns
+    vol_raw_portfolio = np.std(portfolio_returns_np, ddof=1)
+    vol_raw_benchmark = np.std(benchmark_returns_np, ddof=1)
+    vol_raw_growth = np.std(growth_returns_np, ddof=1)
+    vol_raw_value = np.std(value_returns_np, ddof=1)
+    
+# --- 3. Excess Return Calculations ---
+    excess_portfolio_returns = portfolio_returns_np - rf_rates_np
+    excess_benchmark_returns = benchmark_returns_np - rf_rates_np
+    excess_growth_returns = growth_returns_np - rf_rates_np
+    excess_value_returns = value_returns_np - rf_rates_np
+    
+    # --- 4. Sharpe Ratio ---
+    # Volatility of the EXCESS returns (Institutional Standard)
+    vol_excess_p = np.std(excess_portfolio_returns, ddof=1)
+    vol_excess_b = np.std(excess_benchmark_returns, ddof=1)
+    vol_excess_growth = np.std(excess_growth_returns, ddof=1)
+    vol_excess_value = np.std(excess_value_returns, ddof=1)
+
+    # Formula: Mean(Yearly Excess Returns) / Volatility(Yearly Excess Returns)
+    sharpe_portfolio = np.mean(excess_portfolio_returns) / vol_excess_p if vol_excess_p > 0 else 0
+    sharpe_benchmark = np.mean(excess_benchmark_returns) / vol_excess_b if vol_excess_b > 0 else 0
+    sharpe_growth = np.mean(excess_growth_returns) / vol_excess_growth if vol_excess_growth > 0 else 0
+    sharpe_value = np.mean(excess_value_returns) / vol_excess_value if vol_excess_value > 0 else 0
+    
+    # --- 5. Portfolio Beta ---
+    portfolio_beta = None
+    portfolio_beta_growth = None
+    portfolio_beta_value = None
+    if len(portfolio_returns_np) >= 3:
+        # CAPM Beta using excess returns
+        coeffs = np.polyfit(excess_benchmark_returns, excess_portfolio_returns, 1)
+        portfolio_beta = float(coeffs[0])
+        growth_coeffs = np.polyfit(excess_growth_returns, excess_portfolio_returns, 1)
+        portfolio_beta_growth = float(growth_coeffs[0])
+        value_coeffs = np.polyfit(excess_value_returns, excess_portfolio_returns, 1)
+        portfolio_beta_value = float(value_coeffs[0])
+
+    # --- 6. Additional Risk Metrics ---
+    # Information Ratio
+    information_ratio = calculate_information_ratio(portfolio_returns, bench_list, verbosity)
+    information_ratio_growth = calculate_information_ratio(portfolio_returns, growth_bench_list, verbosity)
+    information_ratio_value = calculate_information_ratio(portfolio_returns, value_bench_list, verbosity)
+    
+    # Portfolio Max Drawdown
+    cumulative_values = np.array(portfolio_values)
+    running_peak = np.maximum.accumulate(cumulative_values)
+    max_drawdown_portfolio = np.min((cumulative_values - running_peak) / running_peak)
+    
+    # Benchmark Max Drawdown
+    benchmark_cumulative = [initial_aum]
+    growth_cumulative = [initial_aum]
+    value_cumulative = [initial_aum]
+    for r in benchmark_returns_np:
+        benchmark_cumulative.append(benchmark_cumulative[-1] * (1 + r))
+    for r in growth_returns_np:
+        growth_cumulative.append(growth_cumulative[-1] * (1 + r))
+    for r in value_returns_np:
+        value_cumulative.append(value_cumulative[-1] * (1 + r))
+    
+    benchmark_cumulative_np = np.array(benchmark_cumulative)
+    benchmark_peak = np.maximum.accumulate(benchmark_cumulative_np)
+    max_drawdown_benchmark = np.min((benchmark_cumulative_np - benchmark_peak) / benchmark_peak)
+
+    growth_cumulative_np = np.array(growth_cumulative)
+    growth_peak = np.maximum.accumulate(growth_cumulative_np)
+    max_drawdown_growth = np.min((growth_cumulative_np - growth_peak) / growth_peak)
+
+    value_cumulative_np = np.array(value_cumulative)
+    value_peak = np.maximum.accumulate(value_cumulative_np)
+    max_drawdown_value = np.min((value_cumulative_np - value_peak) / value_peak)
+
+    # Yearly Win Rate
+    wins = 0
+    yearly_comparisons = []
+    for i, (p_ret, b_ret, g_ret, v_ret) in enumerate(zip(portfolio_returns_np, benchmark_returns_np, growth_returns_np, value_returns_np)):
+        win = p_ret > b_ret
+        if win: wins += 1
+        yearly_comparisons.append({
+            'year': years[i+1],
+            'portfolio_return': p_ret * 100,
+            'benchmark_return': b_ret * 100,
+            'win': win,
+            'growth_return': g_ret * 100,
+            'growth_win': p_ret > g_ret,
+            'value_return': v_ret * 100,
+            'value_win': p_ret > v_ret
+        })
+    win_rate = wins / len(portfolio_returns_np) if len(portfolio_returns_np) > 0 else 0
+
+    wins_growth = 0
+    wins_value = 0
+    for p_ret, g_ret, v_ret in zip(portfolio_returns_np, growth_returns_np, value_returns_np):
+        if p_ret > g_ret:
+            wins_growth += 1
+        if p_ret > v_ret:
+            wins_value += 1
+    win_rate_growth = wins_growth / len(portfolio_returns_np) if len(portfolio_returns_np) > 0 else 0
+    win_rate_value = wins_value / len(portfolio_returns_np) if len(portfolio_returns_np) > 0 else 0
+
+    # --- 7. Summary Output ---
+    if verbosity >= 1:
+        print(f"\n==== Performance Metrics ({start_year}-{end_year}) ====")
+        print(f"Final AUM: ${aum:.2f}")
+        print(f"Volatility (Raw Returns, Portfolio): {vol_raw_portfolio:.4%}")
+        print(f"Volatility (Raw Returns, Benchmark): {vol_raw_benchmark:.4%}")
+        print(f"Volatility (Raw Returns, Growth Index): {vol_raw_growth:.4%}")
+        print(f"Volatility (Raw Returns, Value Index): {vol_raw_value:.4%}")
+        print(f"Volatility (Excess Returns, Portfolio): {vol_excess_p:.4%}")
+        print(f"Volatility (Excess Returns, Benchmark): {vol_excess_b:.4%}")
+        print(f"Volatility (Excess Returns, Growth Index): {vol_excess_growth:.4%}")
+        print(f"Volatility (Excess Returns, Value Index): {vol_excess_value:.4%}")
+        print(f"Sharpe Ratio (Portfolio): {sharpe_portfolio:.4f}")
+        print(f"Sharpe Ratio (Benchmark): {sharpe_benchmark:.4f}")
+        print(f"Sharpe Ratio (Growth Index): {sharpe_growth:.4f}")
+        print(f"Sharpe Ratio (Value Index): {sharpe_value:.4f}")
+        if portfolio_beta is not None:
+            print(f"Portfolio Beta: {portfolio_beta:.4f}")
+        if portfolio_beta_growth is not None:
+            print(f"Beta (Portfolio vs Growth Index): {portfolio_beta_growth:.4f}")
+        if portfolio_beta_value is not None:
+            print(f"Beta (Portfolio vs Value Index): {portfolio_beta_value:.4f}")
+        print(f"Max Drawdown (Portfolio): {max_drawdown_portfolio:.2%}")
+        print(f"Max Drawdown (Benchmark): {max_drawdown_benchmark:.2%}")
+        print(f"Max Drawdown (Growth Index): {max_drawdown_growth:.2%}")
+        print(f"Max Drawdown (Value Index): {max_drawdown_value:.2%}")
+        print(f"Win Rate: {win_rate:.2%}")
+        print(f"Win Rate (vs Growth Index): {win_rate_growth:.2%}")
+        print(f"Win Rate (vs Value Index): {win_rate_value:.2%}")
+
+    return {
+        'final_value': aum,
+        'yearly_returns': portfolio_returns,
+        'benchmark_returns': bench_list,
+        'growth_benchmark_returns': growth_bench_list,
+        'value_benchmark_returns': value_bench_list,
+        'years': years,
+        'portfolio_values': portfolio_values,
+        'portfolio_beta': portfolio_beta,
+        'portfolio_beta_growth': portfolio_beta_growth,
+        'portfolio_beta_value': portfolio_beta_value,
+        'max_drawdown_portfolio': max_drawdown_portfolio,
+        'max_drawdown_benchmark': max_drawdown_benchmark,
+        'max_drawdown_growth': max_drawdown_growth,
+        'max_drawdown_value': max_drawdown_value,
+        'sharpe_portfolio': sharpe_portfolio,
+        'sharpe_benchmark': sharpe_benchmark,
+        'sharpe_growth': sharpe_growth,
+        'sharpe_value': sharpe_value,
+        'vol_raw_portfolio': vol_raw_portfolio,
+        'vol_raw_benchmark': vol_raw_benchmark,
+        'vol_raw_growth': vol_raw_growth,
+        'vol_raw_value': vol_raw_value,
+        'vol_excess_portfolio': vol_excess_p,
+        'vol_excess_benchmark': vol_excess_b,
+        'vol_excess_growth': vol_excess_growth,
+        'vol_excess_value': vol_excess_value,
+        'win_rate': win_rate,
+        'win_rate_growth': win_rate_growth,
+        'win_rate_value': win_rate_value,
+        'risk_free_rate_source': risk_free_rate_source,
+        'yearly_comparisons': yearly_comparisons,
+        'information_ratio': information_ratio,
+        'information_ratio_growth': information_ratio_growth,
+        'information_ratio_value': information_ratio_value
+    }

--- a/src/supabase_client.py
+++ b/src/supabase_client.py
@@ -2,7 +2,7 @@ import os
 import pandas as pd
 from supabase import create_client, Client
 
-def load_supabase_data(table_name='Full Precision Test', show_progress=True, sectors=None):
+def load_supabase_data(table_name='Full Precision Test', show_progress=True, sectors=None, start_year=None, end_year=None, data_frequency='Yearly'):
     """
     Loads data from a Supabase table and returns it as a pandas DataFrame.
     Credentials are read from environment variables or Colab userdata.
@@ -11,6 +11,7 @@ def load_supabase_data(table_name='Full Precision Test', show_progress=True, sec
     Args:
         table_name (str): Name of the Supabase table to load
         show_progress (bool): Whether to print loading progress messages
+        data_frequency (str): 'Yearly', 'Monthly', or 'Daily'
     """
     supabase_url = os.environ.get('SUPABASE_URL')
     supabase_key = os.environ.get('SUPABASE_KEY')
@@ -34,40 +35,162 @@ def load_supabase_data(table_name='Full Precision Test', show_progress=True, sec
     if show_progress:
         print(f"Loading data from Supabase table '{table_name}'...")
     
-    while True:
-        # Build base query
-        base_query = supabase.table(table_name).select('*')
-        # Apply server-side sector filter if provided. Uses the exact DB column name.
-        # Column is renamed later to "Scott's Sector (5)" by the loader.
-        if sectors:
-            try:
-                base_query = base_query.in_('Scotts_Sector_5', sectors)
-            except Exception:
-                # If server-side filter isn't supported, we'll filter client-side later
-                pass
+    # Build base query
+    base_query = supabase.table(table_name).select('*')
+    if sectors:
+        try:
+            base_query = base_query.in_('Scotts_Sector_5', sectors)
+        except Exception:
+            pass
 
-        # Fetch a page of data
-        response = base_query.range(offset, offset + page_size - 1).execute()
+    sy = int(start_year) if start_year is not None else 1995
+    ey = int(end_year) if end_year is not None else 2030
+
+    import concurrent.futures
+    import time as _time
+
+    def _paginate_query(query, label="", max_retries=4, page_size=1000):
+        """Paginate a single query with retries. Returns all rows."""
+        rows = []
+        offset = 0
+        while True:
+            result = None
+            for attempt in range(max_retries):
+                try:
+                    res = query.range(offset, offset + page_size - 1).execute()
+                    result = res.data if hasattr(res, 'data') else res
+                    break
+                except Exception as e:
+                    if attempt < max_retries - 1:
+                        _time.sleep(0.5 * (attempt + 1))
+                    else:
+                        print(f"  WARN: Page {offset} failed for {label}: {e}")
+                        result = []
+            
+            if not result or len(result) == 0:
+                break
+            rows.extend(result)
+            if len(result) < page_size:
+                break
+            offset += page_size
+        return rows
+
+    if table_name in ['daily_prices', 'monthly_prices'] and data_frequency in ['Monthly', 'Daily']:
+        # Ultra-fast parallel loading: fetch each MONTH independently
+        # Each month has ~2000 rows (only 2 API pages), so queries are tiny and fast
+        needed_cols = "permno,date,prc,ret,mkt_cap,mom_1m,mom_6m,mom_12m,vol_gk_1m,vol_gk_3m,vol_gk_6m,vol_gk_12m,vol_close_1m,vol_close_3m,vol_close_6m,vol_close_12m"
         
-        batch = response.data if hasattr(response, 'data') else response
+        month_keys = []
+        for y in range(sy, ey + 1):
+            for m in range(1, 13):
+                month_keys.append((y, m))
         
-        if not batch:
-            break
-        
-        all_rows.extend(batch)
         if show_progress:
-            print(f"Loaded {len(all_rows)} records so far...")
+            print(f"Loading {len(month_keys)} months of {data_frequency.lower()} data in parallel...")
         
-        # If we got fewer records than page_size, we're done
-        if len(batch) < page_size:
-            break
+        def fetch_month(ym):
+            year, month = ym
+            last_day = 28 if month == 2 else 30 if month in (4, 6, 9, 11) else 31
+            q = supabase.table(table_name).select(needed_cols)
+            q = q.gte('date', f"{year}-{month:02d}-01").lte('date', f"{year}-{month:02d}-{last_day}")
+            return ym, _paginate_query(q, label=f"{year}-{month:02d}")
         
-        offset += page_size
+        all_rows = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=15) as executor:
+            futures = {executor.submit(fetch_month, ym): ym for ym in month_keys}
+            results = {}
+            for future in concurrent.futures.as_completed(futures):
+                ym, rows = future.result()
+                results[ym] = rows
+        
+        for ym in sorted(results.keys()):
+            all_rows.extend(results[ym])
+        
+        if show_progress:
+            print(f"Loaded {len(all_rows)} total records.")
+    
+    elif table_name in ['daily_prices', 'monthly_prices']:
+        # Yearly mode: December-only for annual backtest
+        if show_progress:
+            print(f"Limiting {table_name} fetch to December dates...")
+        or_conditions = []
+        for y in range(sy, ey + 1):
+            or_conditions.append(f"and(date.gte.{y}-12-01,date.lte.{y}-12-31)")
+        or_str = ",".join(or_conditions)
+        base_query = base_query.or_(or_str)
+        all_rows = _paginate_query(base_query, label=table_name)
+    
+    else:
+        if start_year is not None:
+            if table_name in ['index_monthly', 'index_daily']:
+                base_query = base_query.gte('date', f"{start_year}-01-01")
+            elif table_name == 'Full Precision Test' or table_name == 'Yearly Data':
+                base_query = base_query.gte('Date', f"{start_year}-01-01")
+        if end_year is not None:
+            if table_name in ['index_monthly', 'index_daily']:
+                base_query = base_query.lte('date', f"{end_year}-12-31")
+            elif table_name == 'Full Precision Test' or table_name == 'Yearly Data':
+                base_query = base_query.lte('Date', f"{end_year}-12-31")
+        all_rows = _paginate_query(base_query, label=table_name)
     
     if show_progress:
         print(f"Total records loaded: {len(all_rows)}")
     
     return pd.DataFrame(all_rows)
+
+
+def load_constituents_from_supabase(start_year=None, end_year=None, show_progress=True):
+    """
+    Load Russell 2000 constituent membership data from the Supabase
+    iwm_constituents table.  Returns a DataFrame with columns:
+        permno, index_effective, index_through, ticker, sector, is_fossil_fuel
+    Only returns rows whose membership window overlaps [start_year, end_year].
+    """
+    supabase_url = os.environ.get('SUPABASE_URL')
+    supabase_key = os.environ.get('SUPABASE_KEY')
+    if not supabase_url or not supabase_key:
+        try:
+            from google.colab import userdata
+            supabase_url = userdata.get('SUPABASE_URL')
+            supabase_key = userdata.get('SUPABASE_KEY')
+        except Exception:
+            pass
+    if not supabase_url or not supabase_key:
+        raise RuntimeError('Supabase credentials not set.')
+
+    supabase = create_client(supabase_url, supabase_key)
+
+    if show_progress:
+        print("Loading constituent data from Supabase (iwm_constituents)...")
+
+    # Build query – filter to rows that overlap the requested date window
+    query = supabase.table('iwm_constituents').select('*')
+    if start_year is not None:
+        # constituent must not have left before our start
+        query = query.gte('index_through', f"{int(start_year)}-01-01")
+    if end_year is not None:
+        # constituent must have joined before our end
+        query = query.lte('index_effective', f"{int(end_year)}-12-31")
+
+    # Paginate (table is small – ~5 634 rows – but be safe)
+    page_size = 1000
+    offset = 0
+    all_rows = []
+    while True:
+        res = query.range(offset, offset + page_size - 1).execute()
+        batch = res.data if hasattr(res, 'data') else res
+        if not batch:
+            break
+        all_rows.extend(batch)
+        if len(batch) < page_size:
+            break
+        offset += page_size
+
+    df = pd.DataFrame(all_rows)
+    if show_progress:
+        print(f"Loaded {len(df)} constituent records from Supabase.")
+    return df
+
     
     def load_market_data(self, 
                         table_name: str = 'market_data',


### PR DESCRIPTION
## Changes
- **Volatility Weighting Integration**: Added strict inverse-volatility (Risk Parity) weighting. Removed defunct 'Target Volatility' scaling.
- **Enhanced Rebalancing Frequencies**: With the introduction of Daily data support, users can now choose between Daily, Monthly, Quarterly, and Yearly portfolio rebalancing options.
- **Deterministic Supabase Data Loading**: Completely rewrote the Supabase daily data fetch pipeline to use month-based parallelism (15 concurrent threads). Bypasses Supabase free-tier timeouts.
- **Local Data Caching**: Added `@st.cache_data` wrappers to cache fetched data locally. First run takes 1-2 mins; all subsequent backtests using the same date range are instant.
- **Sharpe Ratio Correction**: Fixed a period counting bug that severely inflated the CAGR numerator for incomplete datasets. It now exclusively uses actual portfolio calendar years (`end_year - start_year + 1`).
- **Sub-Annual Beta & Information Ratio**: These were previously omitted for daily/monthly data frequencies. We now aggregate daily portfolio returns up to yearly for proper regression against the yearly benchmarks.