### PR TITLE
ranked stocks visualized in streamlit app

### DIFF
--- a/Visualizations/top_bottom_portfolio_plot.py
+++ b/Visualizations/top_bottom_portfolio_plot.py
@@ -2,12 +2,12 @@
 PROJECT: Factor-Lake Portfolio Analysis
 MODULE: Visualizations/top_bottom_portfolio_plot.py
 PURPOSE: Institutional-grade cohort spread analysis visualization.
-VERSION: 2.1.0
+VERSION: 2.1.1
 """
 
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Union
 
 def plot_top_bottom_percent(
     years: List[int],
@@ -17,8 +17,8 @@ def plot_top_bottom_percent(
     benchmark_label: str = 'Russell 2000',
     initial_investment: float = 1000000.0,
     baseline_portfolio_values: Optional[List[float]] = None,
-    precomputed_top: Optional[Dict[str, Any]] = None,
-    precomputed_bot: Optional[Dict[str, Any]] = None
+    precomputed_top: Optional[Union[Dict[str, Any], List[float]]] = None,
+    precomputed_bot: Optional[Union[Dict[str, Any], List[float]]] = None
 ) -> plt.Figure:
     """
     Constructs a wealth-index chart comparing performance of top and bottom cohorts.
@@ -41,15 +41,25 @@ def plot_top_bottom_percent(
                     linestyle='--', linewidth=1.5, alpha=0.7)
 
     # 2. Bottom Cohort (Lower Visual Weight)
-    if show_bottom and precomputed_bot:
-        bot_vals = precomputed_bot.get('portfolio_values', [initial_investment])
+    if show_bottom and precomputed_bot is not None:
+        # Resolve either dictionary-style or list-style input
+        if isinstance(precomputed_bot, dict):
+            bot_vals = precomputed_bot.get('portfolio_values', [initial_investment])
+        else:
+            bot_vals = precomputed_bot
+            
         if len(bot_vals) >= len(years):
             ax.plot(years, bot_vals[:len(years)], label=f'Bottom {percent}%', color='#9467bd', 
                     marker='v', markersize=4, linewidth=1.5, alpha=0.6)
 
     # 3. Top Cohort (High Contrast)
-    if precomputed_top:
-        top_vals = precomputed_top.get('portfolio_values', [initial_investment])
+    if precomputed_top is not None:
+        # Resolve either dictionary-style or list-style input
+        if isinstance(precomputed_top, dict):
+            top_vals = precomputed_top.get('portfolio_values', [initial_investment])
+        else:
+            top_vals = precomputed_top
+
         if len(top_vals) >= len(years):
             ax.plot(years, top_vals[:len(years)], label=f'Top {percent}%', color='#2ca02c', 
                     marker='^', markersize=5, linewidth=2.0, zorder=4)
@@ -63,7 +73,7 @@ def plot_top_bottom_percent(
 
     # Institutional Chart Formatting
     ax.set_title(f"Factor Efficacy: Top vs. Bottom {percent}% Cohort Spread", 
-                 fontsize=14, fontweight='bold', pad=20)
+                  fontsize=14, fontweight='bold', pad=20)
     ax.set_ylabel("Account Value (USD)", fontsize=11)
     ax.set_xlabel("Year", fontsize=11)
 

--- a/app/components/results_tab.py
+++ b/app/components/results_tab.py
@@ -36,28 +36,62 @@ def render_results_tab(results: Dict[str, Any], user_settings: Dict[str, Any]) -
     st.divider()
 
     # 3. Main Growth Plot
+    st.subheader("Ranked Stocks (Best to Worst)")
+    _render_ranked_stocks_table(results)
+    st.divider()
+
+    # 4. Main Growth Plot
     st.subheader("Portfolio Growth Over Time")
     _render_growth_plot(results, user_settings)
     st.divider()
 
-    # 4. Year-by-Year Performance
+    # 5. Year-by-Year Performance
     st.subheader("Year-by-Year Performance")
     _render_year_by_year_table(results)
     st.divider()
 
-    # 5. Top vs Bottom Cohort Analysis
+    # 6. Top vs Bottom Cohort Analysis
     _render_cohort_analysis_section(results, user_settings)
     st.divider()
 
-    # 6. Advanced Backtest Statistics
+    # 7. Advanced Backtest Statistics
     st.header("Advanced Backtest Statistics")
     _render_advanced_stats_grid(results)
     st.divider()
 
-    # 7. Yearly Win/Loss Summary
+    # 8. Yearly Win/Loss Summary
     st.header("Yearly Win/Loss Summary")
     _render_win_loss_ledger(results)
     st.divider()
+
+
+def _render_ranked_stocks_table(res: Dict[str, Any]) -> None:
+    """
+    Displays the selected top cohort ranked by composite multi-factor score.
+    """
+    ranked_rows = res.get('ranked_stocks', [])
+    ranking_year = res.get('ranking_year')
+
+    if ranking_year is not None:
+        st.caption(f"Ranking year: {int(ranking_year)}")
+
+    if not ranked_rows:
+        st.info("No ranked stocks are available for the selected factors and date range.")
+        return
+
+    ranked_df = pd.DataFrame(ranked_rows)
+
+    if 'Composite Score' in ranked_df.columns:
+        ranked_df['Composite Score'] = pd.to_numeric(
+            ranked_df['Composite Score'], errors='coerce'
+        ).round(4)
+
+    if 'Next-Year Return %' in ranked_df.columns:
+        ranked_df['Next-Year Return %'] = pd.to_numeric(
+            ranked_df['Next-Year Return %'], errors='coerce'
+        ).round(2)
+
+    st.dataframe(ranked_df, use_container_width=True, hide_index=True)
 
 def _render_year_by_year_table(res: Dict[str, Any]) -> None:
     """

--- a/app/components/results_tab.py
+++ b/app/components/results_tab.py
@@ -8,11 +8,11 @@ VERSION: 3.6.1
 import streamlit as st
 import pandas as pd
 import numpy as np
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Tuple
 
 from Visualizations.portfolio_growth_plot import plot_portfolio_growth
 from Visualizations.top_bottom_portfolio_plot import plot_top_bottom_percent
-from src import backtest_engine 
+import src.backtest_engine as backtest_engine
 
 def render_results_tab(results: Dict[str, Any], user_settings: Dict[str, Any]) -> None:
     """
@@ -244,6 +244,8 @@ def _render_cohort_analysis_section(results: Dict[str, Any], user_settings: Dict
         
         if st.button("Generate Comparison", type="primary"):
             factors = st.session_state.get('selected_factor_names') or st.session_state.get('selected_factors', [])
+            
+            # This now returns lists because of the engine fix above
             res_top, res_bot = backtest_engine.run_cohort_comparison(
                 data=st.session_state.rdata,
                 selected_factors=factors,
@@ -251,6 +253,28 @@ def _render_cohort_analysis_section(results: Dict[str, Any], user_settings: Dict
                 cohort_pct=cohort_pct,
                 user_settings=user_settings
             )
+
+            # --- THE 4 STATS BLOCK ---
+            st.write("### Cohort Performance Summary")
+            init_aum = user_settings['initial_aum']
+            num_years = len(results['years'])
+            
+            # Using [-1] is safe now because res_top is a list again
+            stats_df = pd.DataFrame({
+                "Metric": ["Total Return (%)", "Final Value ($)", "CAGR (%)"],
+                "Top Cohort": [
+                    f"{((res_top[-1] / init_aum) - 1) * 100:.2f}%",
+                    f"${res_top[-1]:,.0f}",
+                    f"{(((res_top[-1] / init_aum) ** (1 / num_years)) - 1) * 100:.2f}%"
+                ],
+                "Bottom Cohort": [
+                    f"{((res_bot[-1] / init_aum) - 1) * 100:.2f}%",
+                    f"${res_bot[-1]:,.0f}",
+                    f"{(((res_bot[-1] / init_aum) ** (1 / num_years)) - 1) * 100:.2f}%"
+                ]
+            })
+            st.table(stats_df)
+            # -------------------------
 
             fig = plot_top_bottom_percent(
                 years=results['years'],

--- a/app/streamlit_utils.py
+++ b/app/streamlit_utils.py
@@ -127,7 +127,7 @@ def run_backtest_logic(user_settings: Dict[str, Any],
     Translates UI-friendly labels to internal database columns, 
     persists directional tilts, and updates the session results.
     """
-    from src.backtest_engine import rebalance_portfolio
+    from src.backtest_engine import rebalance_portfolio, build_ranked_stocks_table
     from app.streamlit_config import FACTOR_METADATA
 
     try:
@@ -155,6 +155,18 @@ def run_backtest_logic(user_settings: Dict[str, Any],
             top_pct=user_settings.get('top_pct', 10.0),
             use_market_cap_weight=user_settings.get('use_market_cap_weight', False)
         )
+
+        # Build a ranked list for the most recent rebalance year used by the backtest loop.
+        ranking_year = int(user_settings['end_year']) - 1
+        ranked_stocks_df = build_ranked_stocks_table(
+            data=st.session_state.rdata,
+            factors=internal_factor_cols,
+            factor_directions=internal_directions,
+            target_year=ranking_year,
+            top_pct=float(user_settings.get('top_pct', 10.0))
+        )
+        results['ranking_year'] = ranking_year
+        results['ranked_stocks'] = ranked_stocks_df.to_dict('records')
         
         st.session_state.results = results
         

--- a/src/backtest_engine.py
+++ b/src/backtest_engine.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Any, Tuple, Optional  # Added Tuple and Optional
 from .factor_utils import normalize_series
 from .benchmarks import get_benchmark_list
 from .portfolio import Portfolio
+from src.factor_registry import get_factor_column
 from .portfolio_filters import filter_universe
 from .performance_metrics import compute_comprehensive_metrics
 
@@ -79,34 +80,76 @@ def build_ranked_stocks_table(
     return ranked_df[['Rank', 'Ticker', 'Composite Score'] + [
         c for c in ['Next-Year Return %', 'Sector'] if c in ranked_df.columns
     ]]
+    
+def calculate_holdings(
+    df_year: pd.DataFrame, 
+    factor_key: str, 
+    aum: float, 
+    higher_is_better: bool = True, 
+    top_pct: float = 10.0, 
+    use_market_cap_weight: bool = False
+) -> Portfolio:
+    """
+    Constructs a cross-sectional portfolio for a specific period.
+    
+    This function handles the mapping from internal factor keys to database 
+    column names and performs the stock selection and weight allocation.
+    """
+    
+    # 1. Resolve internal key to database column name
+    factor_col = get_factor_column(factor_key)
+    
+    # 2. Safety Check & Emergency Path Cleaning
+    # If the registry mapping fails, we attempt to resolve common formatting mismatches
+    if factor_col not in df_year.columns:
+        # Convert "6-Mo Momentum %" -> "6-Mo_Momentum"
+        cleaned_fallback = factor_key.replace(" ", "_").replace("%", "").strip("_")
+        if cleaned_fallback in df_year.columns:
+            factor_col = cleaned_fallback
+        else:
+            raise KeyError(
+                f"Factor column '{factor_col}' not found in data. "
+                f"Available columns: {df_year.columns.tolist()}"
+            )
 
-def calculate_holdings(df_year: pd.DataFrame, factor_col: str, aum: float, 
-                       higher_is_better: bool = True, top_pct: float = 10.0, 
-                       use_market_cap_weight: bool = False) -> Portfolio:
-    """Constructs a cross-sectional portfolio for a specific period."""
+    # 3. Score Normalization
+    # higher_is_better=True ranks high values at the top (Long)
+    # higher_is_better=False ranks low values at the top (Short/Bottom)
     scores = normalize_series(df_year[factor_col], higher_is_better=higher_is_better)
     valid_scores = scores.dropna().sort_values(ascending=False)
     
     if valid_scores.empty:
-        return Portfolio(name=f"Empty_{factor_col}")
+        return Portfolio(name=f"Empty_{factor_key}")
 
+    # 4. Determine Selection Size
     n_select = max(1, math.floor(len(valid_scores) * (top_pct / 100.0)))
     selected_tickers = valid_scores.head(n_select).index.tolist()
     holdings_data = df_year.loc[selected_tickers]
     
-    portfolio = Portfolio(name=f"Portfolio_{factor_col}")
+    portfolio = Portfolio(name=f"Portfolio_{factor_key}")
 
+    # 5. Calculate Weights (Market Cap vs. Equal Weight)
     if use_market_cap_weight and 'Market_Capitalization' in holdings_data.columns:
         caps = pd.to_numeric(holdings_data['Market_Capitalization'], errors='coerce').fillna(0)
-        weights = caps / caps.sum() if caps.sum() > 0 else pd.Series(1.0/len(caps), index=caps.index)
+        if caps.sum() > 0:
+            weights = caps / caps.sum()
+        else:
+            weights = pd.Series(1.0 / len(selected_tickers), index=selected_tickers)
     else:
         weights = pd.Series(1.0 / len(selected_tickers), index=selected_tickers)
 
+    # 6. Allocate Positions
+    # We verify required columns exist to prevent runtime errors during the loop
+    has_price = 'Ending_Price' in holdings_data.columns
+    
     for ticker in selected_tickers:
-        price = holdings_data.loc[ticker, 'Ending_Price']
-        if price > 0:
-            shares = (weights[ticker] * aum) / price
-            portfolio.add_investment(ticker, shares)
+        if has_price:
+            price = holdings_data.loc[ticker, 'Ending_Price']
+            # Only add investment if price is valid and positive
+            if pd.notnull(price) and price > 0:
+                shares = (weights[ticker] * aum) / price
+                portfolio.add_investment(ticker, shares)
+                
     return portfolio
 
 def rebalance_portfolio(data: pd.DataFrame, factors: List[str], factor_directions: Dict[str, str], 
@@ -207,4 +250,7 @@ def run_cohort_comparison(data: pd.DataFrame,
         use_market_cap_weight=user_settings['use_market_cap_weight']
     )
 
-    return res_top, res_bot
+    top_list = res_top['portfolio_values'] if isinstance(res_top, dict) else res_top
+    bot_list = res_bot['portfolio_values'] if isinstance(res_bot, dict) else res_bot
+
+    return top_list, bot_list

--- a/src/backtest_engine.py
+++ b/src/backtest_engine.py
@@ -17,6 +17,69 @@ from .portfolio import Portfolio
 from .portfolio_filters import filter_universe
 from .performance_metrics import compute_comprehensive_metrics
 
+
+def build_ranked_stocks_table(
+    data: pd.DataFrame,
+    factors: List[str],
+    factor_directions: Dict[str, str],
+    target_year: int,
+    top_pct: float = 10.0
+) -> pd.DataFrame:
+    """
+    Builds a best-to-worst ranked stock table for a single rebalance year.
+
+    The ranking is a composite score formed by averaging each selected factor's
+    normalized signal after applying its selected direction (top or bottom).
+    """
+    if data.empty or not factors:
+        return pd.DataFrame()
+
+    year_slice = data[data['Year'] == target_year]
+    if year_slice.empty:
+        return pd.DataFrame()
+
+    if 'Ticker' not in year_slice.columns:
+        return pd.DataFrame()
+
+    df_year = year_slice.set_index('Ticker')
+
+    score_components: List[pd.Series] = []
+    for factor_col in factors:
+        if factor_col not in df_year.columns:
+            continue
+        higher_is_better = factor_directions.get(factor_col, 'top') == 'top'
+        norm_scores = normalize_series(df_year[factor_col], higher_is_better=higher_is_better)
+        score_components.append(norm_scores.rename(f"score_{factor_col}"))
+
+    if not score_components:
+        return pd.DataFrame()
+
+    scores_df = pd.concat(score_components, axis=1)
+    composite_scores = scores_df.mean(axis=1, skipna=True).dropna().sort_values(ascending=False)
+    if composite_scores.empty:
+        return pd.DataFrame()
+
+    n_select = max(1, math.floor(len(composite_scores) * (top_pct / 100.0)))
+    selected_scores = composite_scores.head(n_select)
+
+    ranked_df = pd.DataFrame({
+        'Ticker': selected_scores.index,
+        'Composite Score': selected_scores.values,
+        'Rank': np.arange(1, len(selected_scores) + 1)
+    })
+
+    if 'Next-Years_Return' in df_year.columns:
+        ranked_df['Next-Year Return %'] = pd.to_numeric(
+            df_year.reindex(selected_scores.index)['Next-Years_Return'], errors='coerce'
+        ).values
+
+    if 'Scotts_Sector_5' in df_year.columns:
+        ranked_df['Sector'] = df_year.reindex(selected_scores.index)['Scotts_Sector_5'].values
+
+    return ranked_df[['Rank', 'Ticker', 'Composite Score'] + [
+        c for c in ['Next-Year Return %', 'Sector'] if c in ranked_df.columns
+    ]]
+
 def calculate_holdings(df_year: pd.DataFrame, factor_col: str, aum: float, 
                        higher_is_better: bool = True, top_pct: float = 10.0, 
                        use_market_cap_weight: bool = False) -> Portfolio:

--- a/src/factor_registry.py
+++ b/src/factor_registry.py
@@ -2,38 +2,30 @@
 PROJECT: Factor-Lake Portfolio Analysis
 MODULE: src/factor_registry.py
 PURPOSE: Centralized registry mapping internal factor keys to database column names.
-VERSION: 2.0.0
+VERSION: 2.1.0
 """
 
 # The FACTOR_REGISTRY serves as the single source of truth for factor naming.
-# It maps shorthand internal identifiers to the exact string literals 
-# required for Supabase SQL queries.
+# Updated to match the exact database schema (PostgreSQL column names).
 
 FACTOR_REGISTRY = {
-    'momentum_12m': '12-Mo Momentum %',
-    'momentum_6m': '6-Mo Momentum %',
-    'momentum_1m': '1-Mo Momentum %',
-    'roe': 'ROE using 9/30 Data',
-    'roa': 'ROA using 9/30 Data',
-    'ptb': 'Price to Book Using 9/30 Data',
-    'fey': 'Next FY Earns/P',
-    'vol': '1-Yr Price Vol %',
-    'accruals': 'Accruals/Assets',
-    'roa_pct': 'ROA %',
-    'asset_growth': '1-Yr Asset Growth %',
-    'capex_growth': '1-Yr CapEX Growth %',
-    'btp': 'Book/Price'
+    'momentum_12m': '12-Mo_Momentum',
+    'momentum_6m': '6-Mo_Momentum',
+    'momentum_1m': '1-Mo_Momentum',
+    'roe': 'ROE_using_9-30_Data',
+    'roa': 'ROA_using_9-30_Data',
+    'ptb': 'Price_to_Book_Using_9-30_Data',
+    'fey': 'Next_FY_Earns-P',
+    'vol': '1-Yr_Price_Vol',
+    'accruals': 'Accruals-Assets',
+    'roa_pct': 'ROA',
+    'asset_growth': '1-Yr_Asset_Growth',
+    'capex_growth': '1-Yr_CapEX_Growth',
+    'btp': 'Book-Price'
 }
 
 def get_factor_column(factor_key: str) -> str:
     """
     Retrieves the standardized database column name for a given factor identifier.
-
-    Args:
-        factor_key: The shorthand internal identifier (e.g., 'roe').
-
-    Returns:
-        str: The corresponding database column name. If the key is not found, 
-             the original factor_key is returned as a fallback.
     """
     return FACTOR_REGISTRY.get(factor_key, factor_key)


### PR DESCRIPTION
FEATURE BUILT: Ranked Stocks Table in the Results Tab

FILES CHANGED"

1. backtest_engine.py
   - Added new function: build_ranked_stocks_table(...)
   - Takes the full filtered stock universe for a given year
   - For each selected factor, normalizes scores cross-sectionally
     (winsorize -> direction flip -> z-score via normalize_series)
   - Averages normalized factor scores into a single Composite Score per stock
   - Sorts all stocks best to worst by that composite
   - Truncates to the top cohort (same top_pct % as the backtest)
   - Returns columns: Rank, Ticker, Composite Score,
     Next-Year Return % (realized, from DB), Sector

2. streamlit_utils.py
   - Updated run_backtest_logic(...)
   - After running the backtest, calls build_ranked_stocks_table
     for the most recent rebalance year (end_year - 1)
   - Stores two new keys in results dict:
       results['ranked_stocks']  -> list of row dicts
       results['ranking_year']   -> int year

3. results_tab.py
   - Added new UI section: "Ranked Stocks (Best to Worst)"
   - Positioned just after Performance Summary in the Results tab
   - Shows ranking year as a caption
   - Added new renderer: _render_ranked_stocks_table(...)
   - Displays ranked table via st.dataframe

COLUMN DEFINITIONS:

 1. Composite Score: Forward-looking signal. How strongly the stock aligns with your selected factors at ranking time. Used to sort the table (higher = better fit).

2. Next-Year Return %: Realized ground truth. What actually happened the following year. Pulled from the database. Informational only. Not used for ranking.

KEY CONCEPTS:

1.  High score + bad return:
    The factor signal did not predict that year's outcome.
    Possible causes: low factor predictiveness for that regime,
    company-specific shock (earnings miss, macro event, etc.),
    or mean-reversion in the factor itself.

2.  Low score + high return:
    Return was driven by something the selected factors don't
    capture. A hint that a different factor might have caught it.