### PR TITLE
Time-adjusted delisting strategies with pre-delist returns

### DIFF
--- a/UnitTests/test_calculate_holdings.py
+++ b/UnitTests/test_calculate_holdings.py
@@ -191,21 +191,6 @@ class TestCalculateAnnualReturn:
 
         assert ret == pytest.approx(-0.25, rel=0.01)
 
-    def test_delisted_stock_treated_as_zero(self):
-        """NaN return (delisted) should contribute 0% on main (implicit zero_return)."""
-        df = pd.DataFrame({
-            'Ending_Price': [100.0, 100.0],
-            'Next-Years_Return': [20.0, np.nan],
-        }, index=['AAPL', 'DEAD'])
-
-        portfolios = [self._make_portfolio([('AAPL', 10), ('DEAD', 10)])]
-        ret, count = _calculate_annual_return(portfolios, df)
-
-        # AAPL: 1000 * 0.20 = 200 profit, DEAD: 1000 * 0.0 = 0 profit
-        # Total val = 2000, return = 200/2000 = 10%
-        assert ret == pytest.approx(0.10, rel=0.01)
-        assert count == 1
-
     def test_missing_ticker_ignored(self):
         """Tickers not in df_year should be silently skipped."""
         df = pd.DataFrame({

--- a/UnitTests/test_calculate_holdings.py
+++ b/UnitTests/test_calculate_holdings.py
@@ -1,394 +1,328 @@
 """
-Test suite for calculate_holdings.py module
-Tests portfolio construction, rebalancing, and performance calculations
+Test suite for backtest_engine.py
+Tests portfolio construction (calculate_holdings), annual return calculation
+(_calculate_annual_return), rebalance loop, and benchmark data retrieval.
+
+Rewritten to match the 2026 architecture:
+  - calculate_holdings(df_year, factor_key, aum, ...) operates on a DataFrame
+    indexed by Ticker, not a MarketObject.
+  - _calculate_annual_return replaces calculate_growth; returns (return, delisted_count).
+  - rebalance_portfolio requires factor_directions dict and reads st.session_state.
+  - get_benchmark_list replaces get_benchmark_return.
+  - Information ratio lives in compute_comprehensive_metrics, not a standalone fn.
 """
 import pytest
 import pandas as pd
 import numpy as np
-from src.backtest_engine import (
-    calculate_holdings, calculate_growth, rebalance_portfolio,
-    get_benchmark_return, calculate_information_ratio
-)
-from src.factor_registry import Momentum6m, ROE, ROA
-from src.market_object import MarketObject, load_data
+import streamlit as st
 
+from src.backtest_engine import (
+    calculate_holdings,
+    _calculate_annual_return,
+    rebalance_portfolio,
+)
+from src.benchmarks import get_benchmark_list
+from src.portfolio import Portfolio
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def ten_stock_df():
+    """DataFrame indexed by Ticker with 10 stocks, mimicking a single-year slice."""
+    df = pd.DataFrame({
+        'Ending_Price': [150, 300, 2800, 3200, 350, 700, 450, 140, 220, 145],
+        '6-Mo_Momentum': [0.20, 0.25, 0.15, 0.30, 0.18, 0.35, 0.28, 0.12, 0.22, 0.10],
+        'ROE_using_9-30_Data': [0.25, 0.30, 0.22, 0.28, 0.20, 0.15, 0.35, 0.18, 0.32, 0.16],
+        'Next-Years_Return': [10, 15, -5, 20, 8, 25, 30, -2, 12, 5],
+        'Market_Capitalization': [2e9, 1.5e9, 3e9, 5e9, 1e9, 4e9, 2.5e9, 0.8e9, 1.2e9, 0.6e9],
+    }, index=['AAPL', 'MSFT', 'GOOGL', 'AMZN', 'META', 'TSLA', 'NVDA', 'JPM', 'V', 'WMT'])
+    df.index.name = 'Ticker'
+    return df
+
+
+@pytest.fixture
+def multi_year_data():
+    """Long-format DataFrame with Ticker/Year columns for 3 years × 10 stocks.
+    Next-Years_Return is seeded deterministically."""
+    rng = np.random.RandomState(42)
+    rows = []
+    tickers = ['AAPL', 'MSFT', 'GOOGL', 'AMZN', 'META',
+               'TSLA', 'NVDA', 'JPM', 'V', 'WMT']
+    for year in range(2020, 2023):
+        for t in tickers:
+            rows.append({
+                'Ticker': t,
+                'Year': year,
+                'Ending_Price': rng.uniform(50, 500),
+                '6-Mo_Momentum': rng.uniform(-0.1, 0.4),
+                'ROE_using_9-30_Data': rng.uniform(0.05, 0.35),
+                'ROA_using_9-30_Data': rng.uniform(0.02, 0.20),
+                'Next-Years_Return': rng.uniform(-20, 40),
+            })
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture(autouse=True)
+def _mock_session_state():
+    """Ensure st.session_state has the keys filter_universe reads."""
+    st.session_state['exclude_fossil_fuels'] = False
+    st.session_state['selected_sectors'] = []
+
+
+# ---------------------------------------------------------------------------
+# calculate_holdings
+# ---------------------------------------------------------------------------
 
 class TestCalculateHoldings:
-    """Test calculate_holdings function"""
-    
-    @pytest.fixture
-    def sample_market_data(self):
-        """Create sample market data"""
-        return pd.DataFrame({
-            'Ticker-Region': ['AAPL-US', 'MSFT-US', 'GOOGL-US', 'AMZN-US', 'META-US',
-                             'TSLA-US', 'NVDA-US', 'JPM-US', 'V-US', 'WMT-US'],
-            'Ending Price': [150.0, 300.0, 2800.0, 3200.0, 350.0,
-                            700.0, 450.0, 140.0, 220.0, 145.0],
-            '6-Mo Momentum %': [0.20, 0.25, 0.15, 0.30, 0.18,
-                               0.35, 0.28, 0.12, 0.22, 0.10],
-            'Year': [2022] * 10
-        })
-    
-    @pytest.fixture
-    def market(self, sample_market_data):
-        """Create a market object"""
-        return MarketObject(sample_market_data, 2022)
-    
-    def test_calculate_holdings_basic(self, market):
-        """Test basic portfolio construction"""
-        factor = Momentum6m()
-        aum = 10000.0
-        
-        portfolio = calculate_holdings(factor, aum, market)
-        
-        assert portfolio is not None
+    """Tests for calculate_holdings(df_year, factor_key, aum, ...)."""
+
+    def test_basic_construction(self, ten_stock_df):
+        """Should return a non-empty Portfolio."""
+        portfolio = calculate_holdings(ten_stock_df, '6-Mo_Momentum', 10_000)
         assert len(portfolio.investments) > 0
-        assert portfolio.investments[0]['number_of_shares'] > 0
-    
-    def test_calculate_holdings_top_10_percent(self, market):
-        """Test that only top 10% of stocks are selected"""
-        factor = Momentum6m()
-        aum = 10000.0
-        
-        portfolio = calculate_holdings(factor, aum, market)
-        
-        # With 10 stocks, top 10% = 1 stock
+
+    def test_top_10_percent_selects_one(self, ten_stock_df):
+        """With 10 stocks and top_pct=10, exactly 1 stock should be selected."""
+        portfolio = calculate_holdings(ten_stock_df, '6-Mo_Momentum', 10_000, top_pct=10.0)
         assert len(portfolio.investments) == 1
-    
-    def test_calculate_holdings_equal_weighting(self, market):
-        """Test equal weighting of selected stocks"""
-        factor = Momentum6m()
-        aum = 10000.0
-        
-        portfolio = calculate_holdings(factor, aum, market)
-        
-        # Calculate total portfolio value
-        total_value = sum(
-            inv['number_of_shares'] * market.get_price(inv['ticker'])
+
+    def test_total_value_equals_aum(self, ten_stock_df):
+        """Total position value should approximate AUM."""
+        aum = 10_000
+        portfolio = calculate_holdings(ten_stock_df, '6-Mo_Momentum', aum, top_pct=10.0)
+        total = sum(
+            inv['number_of_shares'] * ten_stock_df.loc[inv['ticker'], 'Ending_Price']
             for inv in portfolio.investments
         )
-        
-        # Should be approximately equal to AUM
-        assert total_value == pytest.approx(aum, rel=0.01)
-    
-    def test_calculate_holdings_selects_highest_factor(self, market):
-        """Test that stocks with highest factor values are selected"""
-        factor = Momentum6m()
-        aum = 10000.0
-        
-        portfolio = calculate_holdings(factor, aum, market)
-        
-        # TSLA has highest momentum (0.35), should be selected
-        selected_tickers = [inv['ticker'] for inv in portfolio.investments]
-        assert 'TSLA' in selected_tickers
-    
-    def test_calculate_holdings_with_missing_values(self):
-        """Test portfolio construction with missing factor values"""
-        data = pd.DataFrame({
-            'Ticker-Region': ['AAPL-US', 'MSFT-US', 'GOOGL-US'],
-            'Ending Price': [150.0, 300.0, 2800.0],
-            '6-Mo Momentum %': [0.20, np.nan, 0.15],  # MSFT has NaN
-            'Year': [2022, 2022, 2022]
-        })
-        market = MarketObject(data, 2022)
-        
-        factor = Momentum6m()
-        portfolio = calculate_holdings(factor, 10000.0, market)
-        
-        # Should only include stocks with valid values
-        selected_tickers = [inv['ticker'] for inv in portfolio.investments]
-        assert 'MSFT' not in selected_tickers
-    
-    @pytest.mark.skip(reason="Fossil fuel filtering needs fixing in calculate_holdings")
-    def test_calculate_holdings_fossil_fuel_restriction(self):
-        """Test fossil fuel restriction"""
-        data = pd.DataFrame({
-            'Ticker-Region': ['AAPL-US', 'XOM-US', 'MSFT-US', 'GOOGL-US', 'TSLA-US'],
-            'Ending Price': [150.0, 100.0, 300.0, 2800.0, 700.0],
-            '6-Mo Momentum %': [0.20, 0.35, 0.15, 0.25, 0.30],  # XOM has highest momentum
-            'FactSet Industry': ['Technology', 'Oil & Gas', 'Technology', 'Technology', 'Automotive'],
-            'Year': [2022, 2022, 2022, 2022, 2022]
-        })
-        market = MarketObject(data, 2022)
-        
-        factor = Momentum6m()
-        portfolio = calculate_holdings(factor, 10000.0, market, restrict_fossil_fuels=True)
-        
-        # XOM should be excluded despite having high momentum
-        selected_tickers = [inv['ticker'] for inv in portfolio.investments]
-        assert 'XOM' not in selected_tickers, f"XOM should be excluded but found in {selected_tickers}"
-        # Should select from non-fossil fuel companies
-        assert len(selected_tickers) > 0, "Should have selected some companies"
+        assert total == pytest.approx(aum, rel=0.01)
 
+    def test_selects_highest_factor(self, ten_stock_df):
+        """The stock with the highest raw factor value should be selected at top_pct=10."""
+        portfolio = calculate_holdings(ten_stock_df, '6-Mo_Momentum', 10_000, top_pct=10.0)
+        selected = [inv['ticker'] for inv in portfolio.investments]
+        # TSLA has highest 6-Mo_Momentum (0.35)
+        assert 'TSLA' in selected
 
-class TestCalculateGrowth:
-    """Test calculate_growth function"""
-    
-    @pytest.fixture
-    def portfolio_list(self):
-        """Create a list of portfolios"""
-        from src.portfolio import Portfolio
-
-        portfolio = Portfolio(name="Test Portfolio")
-        portfolio.add_investment('AAPL', 10)
-        portfolio.add_investment('MSFT', 5)
-
-        return [portfolio]
-    @pytest.fixture
-    def current_market(self):
-        """Create current market"""
-        data = pd.DataFrame({
-            'Ticker-Region': ['AAPL-US', 'MSFT-US'],
-            'Ending Price': [100.0, 200.0],
-            'Year': [2021, 2021]
-        })
-        return MarketObject(data, 2021)
-    
-    @pytest.fixture
-    def next_market(self):
-        """Create next year market"""
-        data = pd.DataFrame({
-            'Ticker-Region': ['AAPL-US', 'MSFT-US'],
-            'Ending Price': [150.0, 250.0],
-            'Year': [2022, 2022]
-        })
-        return MarketObject(data, 2022)
-    
-    def test_calculate_growth_positive(self, portfolio_list, current_market, next_market):
-        """Test calculating positive growth"""
-        growth, start_value, end_value = calculate_growth(
-            portfolio_list, next_market, current_market, verbosity=0
+    def test_bottom_direction(self, ten_stock_df):
+        """higher_is_better=False should select the lowest-scoring stock."""
+        portfolio = calculate_holdings(
+            ten_stock_df, '6-Mo_Momentum', 10_000,
+            higher_is_better=False, top_pct=10.0
         )
-        
-        # Start: 10*100 + 5*200 = 2000
-        # End: 10*150 + 5*250 = 2750
-        # Growth: (2750-2000)/2000 = 0.375
-        
-        assert start_value == 2000.0
-        assert end_value == 2750.0
-        assert growth == pytest.approx(0.375, rel=0.01)
-    
-    def test_calculate_growth_negative(self, portfolio_list, current_market):
-        """Test calculating negative growth"""
-        # Market with declining prices
-        declining_market = MarketObject(pd.DataFrame({
-            'Ticker-Region': ['AAPL-US', 'MSFT-US'],
-            'Ending Price': [80.0, 150.0],
-            'Year': [2022, 2022]
-        }), 2022)
-        
-        growth, start_value, end_value = calculate_growth(
-            portfolio_list, declining_market, current_market, verbosity=0
-        )
-        
-        assert growth < 0  # Negative growth
-        assert end_value < start_value
-    
-    def test_calculate_growth_with_missing_stock(self, portfolio_list, current_market):
-        """Test growth calculation when stock missing in next market"""
-        # Next market missing MSFT
-        partial_market = MarketObject(pd.DataFrame({
-            'Ticker-Region': ['AAPL-US'],
-            'Ending Price': [150.0],
-            'Year': [2022]
-        }), 2022)
-        
-        growth, start_value, end_value = calculate_growth(
-            portfolio_list, partial_market, current_market, verbosity=0
-        )
-        
-        # Should use entry price for MSFT
-        assert end_value > 0
-        assert start_value == 2000.0
+        selected = [inv['ticker'] for inv in portfolio.investments]
+        # WMT has lowest 6-Mo_Momentum (0.10)
+        assert 'WMT' in selected
 
+    def test_missing_factor_values(self):
+        """Stocks with NaN factor values should be excluded."""
+        df = pd.DataFrame({
+            'Ending_Price': [150, 300, 2800],
+            '6-Mo_Momentum': [0.20, np.nan, 0.15],
+            'Next-Years_Return': [10, 15, -5],
+        }, index=['AAPL', 'MSFT', 'GOOGL'])
+        df.index.name = 'Ticker'
+
+        portfolio = calculate_holdings(df, '6-Mo_Momentum', 10_000, top_pct=50.0)
+        selected = [inv['ticker'] for inv in portfolio.investments]
+        assert 'MSFT' not in selected
+
+    def test_market_cap_weighting(self, ten_stock_df):
+        """Market-cap weighting should allocate more to larger-cap stocks."""
+        portfolio = calculate_holdings(
+            ten_stock_df, '6-Mo_Momentum', 100_000,
+            top_pct=30.0, use_market_cap_weight=True
+        )
+        # With cap weighting, different stocks get different share counts
+        shares = {inv['ticker']: inv['number_of_shares'] for inv in portfolio.investments}
+        assert len(shares) > 0
+
+    def test_unknown_factor_key_raises(self, ten_stock_df):
+        """A factor key that doesn't resolve to any column should raise KeyError."""
+        with pytest.raises(KeyError):
+            calculate_holdings(ten_stock_df, 'totally_bogus_factor', 10_000)
+
+
+# ---------------------------------------------------------------------------
+# _calculate_annual_return
+# ---------------------------------------------------------------------------
+
+class TestCalculateAnnualReturn:
+    """Tests for _calculate_annual_return (replaces old calculate_growth).
+
+    NOTE: On main, _calculate_annual_return returns a single float.
+    The delisting-strategy-v2 branch extends this to return (float, int)
+    with a delisting_strategy kwarg. These tests target the main API;
+    delisting-specific tests live in test_delisting_strategy.py.
+    """
+
+    def _make_portfolio(self, holdings):
+        """Helper: create a Portfolio from a list of (ticker, shares) tuples."""
+        p = Portfolio(name='test')
+        for ticker, shares in holdings:
+            p.add_investment(ticker, shares)
+        return p
+
+    def test_positive_return(self):
+        """All live positions with positive returns → positive aggregate return."""
+        df = pd.DataFrame({
+            'Ending_Price': [100.0, 200.0],
+            'Next-Years_Return': [20.0, 10.0],  # 20% and 10%
+        }, index=['AAPL', 'MSFT'])
+
+        portfolios = [self._make_portfolio([('AAPL', 10), ('MSFT', 5)])]
+        ret, _ = _calculate_annual_return(portfolios, df)
+
+        # AAPL: 1000 * 0.20 = 200, MSFT: 1000 * 0.10 = 100
+        # Total val = 2000, profit = 300, return = 15%
+        assert ret == pytest.approx(0.15, rel=0.01)
+
+    def test_negative_return(self):
+        """Negative Next-Years_Return values → negative aggregate return."""
+        df = pd.DataFrame({
+            'Ending_Price': [100.0],
+            'Next-Years_Return': [-25.0],
+        }, index=['AAPL'])
+
+        portfolios = [self._make_portfolio([('AAPL', 10)])]
+        ret, _ = _calculate_annual_return(portfolios, df)
+
+        assert ret == pytest.approx(-0.25, rel=0.01)
+
+    def test_delisted_stock_treated_as_zero(self):
+        """NaN return (delisted) should contribute 0% on main (implicit zero_return)."""
+        df = pd.DataFrame({
+            'Ending_Price': [100.0, 100.0],
+            'Next-Years_Return': [20.0, np.nan],
+        }, index=['AAPL', 'DEAD'])
+
+        portfolios = [self._make_portfolio([('AAPL', 10), ('DEAD', 10)])]
+        ret, count = _calculate_annual_return(portfolios, df)
+
+        # AAPL: 1000 * 0.20 = 200 profit, DEAD: 1000 * 0.0 = 0 profit
+        # Total val = 2000, return = 200/2000 = 10%
+        assert ret == pytest.approx(0.10, rel=0.01)
+        assert count == 1
+
+    def test_missing_ticker_ignored(self):
+        """Tickers not in df_year should be silently skipped."""
+        df = pd.DataFrame({
+            'Ending_Price': [100.0],
+            'Next-Years_Return': [10.0],
+        }, index=['AAPL'])
+
+        portfolios = [self._make_portfolio([('AAPL', 10), ('GONE', 5)])]
+        ret, _ = _calculate_annual_return(portfolios, df)
+
+        assert ret == pytest.approx(0.10, rel=0.01)
+
+    def test_empty_portfolio(self):
+        """Empty portfolio should return 0.0."""
+        df = pd.DataFrame({
+            'Ending_Price': [100.0],
+            'Next-Years_Return': [10.0],
+        }, index=['AAPL'])
+
+        portfolios = [self._make_portfolio([])]
+        ret, count = _calculate_annual_return(portfolios, df)
+        assert ret == 0.0
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# rebalance_portfolio (integration-level, synthetic data)
+# ---------------------------------------------------------------------------
 
 class TestRebalancePortfolio:
-    """Test rebalance_portfolio function"""
-    
-    @pytest.fixture
-    def sample_data(self):
-        """Create sample data for multiple years"""
-        data = []
-        for year in range(2020, 2023):
-            for ticker in ['AAPL', 'MSFT', 'GOOGL', 'AMZN', 'META',
-                          'TSLA', 'NVDA', 'JPM', 'V', 'WMT']:
-                data.append({
-                    'Ticker-Region': f'{ticker}-US',
-                    'Ending Price': np.random.uniform(100, 500),
-                    '6-Mo Momentum %': np.random.uniform(0.05, 0.30),
-                    'ROE using 9/30 Data': np.random.uniform(0.10, 0.40),
-                    'ROA using 9/30 Data': np.random.uniform(0.05, 0.25),
-                    'Year': year
-                })
-        
-        return pd.DataFrame(data)
-    
-    def test_rebalance_portfolio_basic(self, sample_data):
-        """Test basic portfolio rebalancing"""
-        factors = [Momentum6m()]
-        
+    """Tests for the full rebalance_portfolio loop using synthetic data."""
+
+    def test_basic_run(self, multi_year_data):
+        """Should complete and return a dict with expected keys."""
         results = rebalance_portfolio(
-            sample_data, factors,
+            multi_year_data,
+            factors=['6-Mo_Momentum'],
+            factor_directions={'6-Mo_Momentum': 'top'},
             start_year=2020, end_year=2022,
             initial_aum=1.0,
-            verbosity=0
         )
-        
-        assert 'final_value' in results
-        assert 'yearly_returns' in results
-        assert 'benchmark_returns' in results
-        assert results['final_value'] > 0
-    
-    def test_rebalance_portfolio_multiple_factors(self, sample_data):
-        """Test rebalancing with multiple factors"""
-        factors = [Momentum6m(), ROE(), ROA()]
-        
-        results = rebalance_portfolio(
-            sample_data, factors,
-            start_year=2020, end_year=2022,
-            initial_aum=1.0,
-            verbosity=0
-        )
-        
-        assert results['final_value'] > 0
-        assert len(results['yearly_returns']) == 2  # 2 years of returns
-    
-    def test_rebalance_portfolio_returns_structure(self, sample_data):
-        """Test that rebalance returns correct structure"""
-        factors = [Momentum6m()]
-        
-        results = rebalance_portfolio(
-            sample_data, factors,
-            start_year=2020, end_year=2022,
-            initial_aum=1.0,
-            verbosity=0
-        )
-        
         assert isinstance(results, dict)
         assert 'final_value' in results
         assert 'yearly_returns' in results
-        assert 'benchmark_returns' in results
-        assert 'years' in results
         assert 'portfolio_values' in results
-    
-    def test_rebalance_portfolio_years_length(self, sample_data):
-        """Test that years and values have correct length"""
-        factors = [Momentum6m()]
-        
+        assert results['final_value'] > 0
+
+    def test_multiple_factors(self, multi_year_data):
+        """Multiple factors should run without error."""
         results = rebalance_portfolio(
-            sample_data, factors,
+            multi_year_data,
+            factors=['6-Mo_Momentum', 'ROE_using_9-30_Data'],
+            factor_directions={
+                '6-Mo_Momentum': 'top',
+                'ROE_using_9-30_Data': 'top',
+            },
             start_year=2020, end_year=2022,
             initial_aum=1.0,
-            verbosity=0
         )
-        
-        # Should have 3 years: 2020, 2021, 2022
-        assert len(results['years']) == 3
-        assert len(results['portfolio_values']) == 3
+        assert results['final_value'] > 0
+        assert len(results['yearly_returns']) == 2
+
+    def test_portfolio_values_length(self, multi_year_data):
+        """portfolio_values should have n_years + 1 entries (initial + each year-end)."""
+        results = rebalance_portfolio(
+            multi_year_data,
+            factors=['6-Mo_Momentum'],
+            factor_directions={'6-Mo_Momentum': 'top'},
+            start_year=2020, end_year=2022,
+            initial_aum=1.0,
+        )
+        assert len(results['portfolio_values']) == 3  # initial + 2 year-ends
+
+    def test_deterministic(self, multi_year_data):
+        """Same inputs should produce same outputs (no random state leakage)."""
+        kwargs = dict(
+            factors=['6-Mo_Momentum'],
+            factor_directions={'6-Mo_Momentum': 'top'},
+            start_year=2020, end_year=2022,
+            initial_aum=1.0,
+        )
+        r1 = rebalance_portfolio(multi_year_data, **kwargs)
+        r2 = rebalance_portfolio(multi_year_data, **kwargs)
+        assert r1['final_value'] == r2['final_value']
 
 
-class TestBenchmarkReturn:
-    """Test benchmark return function"""
-    
-    def test_get_benchmark_return_known_years(self):
-        """Test getting benchmark returns for known years"""
-        # Test a few known years
-        assert get_benchmark_return(2002) == 34.62
-        assert get_benchmark_return(2010) == -4.73
-        assert get_benchmark_return(2020) == 46.21
-    
-    def test_get_benchmark_return_unknown_year(self):
-        """Test getting benchmark return for unknown year"""
-        # Should return 0 for unknown years
-        assert get_benchmark_return(1999) == 0
-        assert get_benchmark_return(2050) == 0
+# ---------------------------------------------------------------------------
+# Benchmarks (get_benchmark_list replaces get_benchmark_return)
+# ---------------------------------------------------------------------------
 
+class TestBenchmarks:
+    """Tests for get_benchmark_list from benchmarks.py."""
 
-class TestInformationRatio:
-    """Test information ratio calculation"""
-    
-    def test_calculate_information_ratio_positive(self):
-        """Test calculating positive information ratio"""
-        portfolio_returns = [0.10, 0.12, 0.15, 0.08, 0.14]
-        benchmark_returns = [0.08, 0.09, 0.10, 0.07, 0.11]
-        
-        ir = calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity=0)
-        
-        assert ir is not None
-        assert ir > 0  # Portfolio outperformed benchmark
-    
-    def test_calculate_information_ratio_negative(self):
-        """Test calculating negative information ratio"""
-        portfolio_returns = [0.05, 0.06, 0.07, 0.04, 0.08]
-        benchmark_returns = [0.08, 0.09, 0.10, 0.07, 0.11]
-        
-        ir = calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity=0)
-        
-        assert ir is not None
-        assert ir < 0  # Portfolio underperformed benchmark
-    
-    def test_calculate_information_ratio_zero_tracking_error(self):
-        """Test IR calculation with zero tracking error"""
-        portfolio_returns = [0.10, 0.10, 0.10]
-        benchmark_returns = [0.10, 0.10, 0.10]
-        
-        ir = calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity=0)
-        
-        assert ir is None  # Should return None when tracking error is 0
-    
-    def test_calculate_information_ratio_with_numpy_arrays(self):
-        """Test IR calculation with numpy arrays"""
-        portfolio_returns = np.array([0.10, 0.12, 0.15])
-        benchmark_returns = np.array([0.08, 0.09, 0.10])
-        
-        ir = calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity=0)
-        
-        assert ir is not None
-        assert isinstance(ir, (float, np.floating))
+    def test_known_year_russell2000(self):
+        """Russell 2000 returns for known years should match hardcoded data."""
+        # index 1 = Russell 2000; 2002 return is -9.30
+        vals = get_benchmark_list(1, 2002, 2003)
+        assert len(vals) == 1
+        assert vals[0] == -9.30
 
+    def test_risk_free_rates(self):
+        """Risk-free rate for 2002 should be 0.0156."""
+        vals = get_benchmark_list(4, 2002, 2003)
+        assert len(vals) == 1
+        assert vals[0] == pytest.approx(0.0156)
 
-class TestCalculateHoldingsIntegration:
-    """Integration tests with real data"""
-    
-    @pytest.fixture
-    def real_data(self):
-        """Load real data"""
-        return load_data(use_supabase=True)
-    
-    @pytest.mark.skip(reason="Requires Supabase credentials")
-    def test_calculate_holdings_with_real_data(self, real_data):
-        """Test calculate_holdings with real data"""
-        year = 2022
-        year_data = real_data[real_data['Year'] == year]
-        
-        if len(year_data) > 0:
-            market = MarketObject(year_data, year)
-            factor = Momentum6m()
-            
-            portfolio = calculate_holdings(factor, 10000.0, market)
-            
-            assert portfolio is not None
-            assert len(portfolio.investments) > 0
-            
-            # Verify total investment is close to AUM
-            total_value = portfolio.present_value(market)
-            assert total_value > 0
-    
-    @pytest.mark.skip(reason="Requires Supabase credentials")
-    def test_rebalance_with_real_data_subset(self, real_data):
-        """Test rebalancing with real data (short period)"""
-        # Test with just 2 years to keep test fast
-        test_data = real_data[real_data['Year'].isin([2021, 2022])]
-        
-        if len(test_data) > 0:
-            factors = [Momentum6m()]
-            
-            results = rebalance_portfolio(
-                test_data, factors,
-                start_year=2021, end_year=2022,
-                initial_aum=1.0,
-                verbosity=0
-            )
-            
-            assert results['final_value'] > 0
-            assert len(results['yearly_returns']) >= 0
+    def test_multi_year_range(self):
+        """Requesting multiple years should return correct count."""
+        vals = get_benchmark_list(1, 2002, 2005)
+        assert len(vals) == 3  # 2002, 2003, 2004
+
+    def test_unknown_year_returns_zero(self):
+        """Years outside the data range should return 0.0 (fallback)."""
+        vals = get_benchmark_list(1, 1990, 1991)
+        assert vals == [0.0]
+
+    def test_invalid_index_raises(self):
+        """Invalid benchmark index should raise ValueError."""
+        with pytest.raises(ValueError):
+            get_benchmark_list(99, 2002, 2003)

--- a/UnitTests/test_delisting_strategy.py
+++ b/UnitTests/test_delisting_strategy.py
@@ -185,6 +185,80 @@ class TestEdgeCases:
         ret, _ = _calculate_annual_return([p], df, delisting_strategy='reinvest', rebalance_year=2010)
         assert ret == pytest.approx(0.0, abs=1e-9)
 
+    def test_pre_delist_return_positive(self):
+        """Stock gains 50% before delisting; post-delist capital reflects that."""
+        df = pd.DataFrame({
+            'Ending_Price': [100.0, 100.0],
+            'Next-Years_Return': [20.0, np.nan],
+            'Delist_Date': [pd.NaT, pd.Timestamp('2011-07-01')],
+            'Delist_Price': [np.nan, 150.0],  # gained 50%
+        }, index=['LIVE', 'DEAD'])
+        p = Portfolio(name="test")
+        p.add_investment('LIVE', 1.0)
+        p.add_investment('DEAD', 1.0)
+
+        frac = (datetime.date(2011, 12, 31) - datetime.date(2011, 7, 1)).days / 365.0
+        pre_profit = 100.0 * 0.50  # 50% gain before delist
+        capital_at_delist = 150.0
+        rf = 0.04
+
+        # hold_cash: live profit + pre-delist profit + rf on capital_at_delist
+        ret, count = _calculate_annual_return(
+            [p], df, delisting_strategy='hold_cash', risk_free_rate=rf, rebalance_year=2010
+        )
+        live_profit = 100.0 * 0.20
+        post_profit = rf * frac * capital_at_delist
+        expected = (live_profit + pre_profit + post_profit) / 200.0
+        assert ret == pytest.approx(expected, abs=1e-9)
+        assert count == 1
+
+    def test_pre_delist_return_negative(self):
+        """Stock crashes 80% before delisting; post-delist capital is small."""
+        df = pd.DataFrame({
+            'Ending_Price': [100.0],
+            'Next-Years_Return': [np.nan],
+            'Delist_Date': [pd.Timestamp('2011-03-01')],
+            'Delist_Price': [20.0],  # lost 80%
+        }, index=['DEAD'])
+        p = Portfolio(name="test")
+        p.add_investment('DEAD', 1.0)
+
+        frac = (datetime.date(2011, 12, 31) - datetime.date(2011, 3, 1)).days / 365.0
+        pre_profit = 100.0 * -0.80  # -80
+        capital_at_delist = 20.0
+
+        # zero_return: pre-delist loss counted, no post-delist profit
+        ret, _ = _calculate_annual_return(
+            [p], df, delisting_strategy='zero_return', rebalance_year=2010
+        )
+        expected = pre_profit / 100.0  # -80/100 = -0.80
+        assert ret == pytest.approx(expected, abs=1e-9)
+
+        # hold_cash: pre-delist loss + small RF on remaining capital
+        ret, _ = _calculate_annual_return(
+            [p], df, delisting_strategy='hold_cash', risk_free_rate=0.05, rebalance_year=2010
+        )
+        expected = (pre_profit + 0.05 * frac * capital_at_delist) / 100.0
+        assert ret == pytest.approx(expected, abs=1e-9)
+
+    def test_pre_delist_return_missing_price_defaults_zero(self):
+        """No Delist_Price column → partial return is 0%, same as before."""
+        df = pd.DataFrame({
+            'Ending_Price': [100.0, 100.0],
+            'Next-Years_Return': [10.0, np.nan],
+            'Delist_Date': [pd.NaT, pd.Timestamp('2011-07-01')],
+        }, index=['LIVE', 'DEAD'])
+        p = Portfolio(name="test")
+        p.add_investment('LIVE', 1.0)
+        p.add_investment('DEAD', 1.0)
+
+        # No Delist_Price → pre_profit=0, capital_at_delist=100
+        ret, _ = _calculate_annual_return(
+            [p], df, delisting_strategy='zero_return', rebalance_year=2010
+        )
+        # Live: 100*0.10=10, Dead pre: 0, Dead post: 0 → 10/200 = 0.05
+        assert ret == pytest.approx(0.05, abs=1e-9)
+
     def test_delist_date_dec31_full_year(self):
         """Stock with Delist_Date on Dec 31 of holding year => fraction ~0."""
         df = pd.DataFrame({

--- a/UnitTests/test_delisting_strategy.py
+++ b/UnitTests/test_delisting_strategy.py
@@ -1,8 +1,10 @@
 """
-Test suite for delisting strategy functionality.
+Test suite for time-adjusted delisting strategy functionality.
 Tests the three delisting modes: zero_return, hold_cash, reinvest.
+Time fractions are derived from Delist_Date; missing dates default to 0.5.
 """
 import pytest
+import datetime
 import pandas as pd
 import numpy as np
 
@@ -13,9 +15,20 @@ from src.portfolio import Portfolio
 @pytest.fixture
 def df_year_with_delisted():
     """
-    Synthetic year-slice with 3 live stocks and 1 delisted (NaN return).
-    All stocks priced at $100 for simple math.
+    Synthetic year-slice (formation year 2010, holding period 2011).
+    3 live stocks + 1 delisted mid-year (July 1 => ~183 days remaining => fraction ~0.5014).
+    All priced at $100 for simple math.
     """
+    return pd.DataFrame({
+        'Ending_Price': [100.0, 100.0, 100.0, 100.0],
+        'Next-Years_Return': [10.0, 20.0, 30.0, np.nan],
+        'Delist_Date': [pd.NaT, pd.NaT, pd.NaT, pd.Timestamp('2011-07-01')],
+    }, index=['AAPL', 'MSFT', 'GOOGL', 'DEAD'])
+
+
+@pytest.fixture
+def df_year_no_delist_date():
+    """Same as above but without Delist_Date column — should fall back to 0.5."""
     return pd.DataFrame({
         'Ending_Price': [100.0, 100.0, 100.0, 100.0],
         'Next-Years_Return': [10.0, 20.0, 30.0, np.nan],
@@ -31,77 +44,91 @@ def portfolios_with_delisted():
     return [p]
 
 
+# --- Fraction helper ---
+def _july1_fraction():
+    """Fraction of year remaining after July 1 in a 2011 holding period."""
+    return (datetime.date(2011, 12, 31) - datetime.date(2011, 7, 1)).days / 365.0
+
+
 class TestZeroReturn:
-    """Delisted capital earns 0%."""
+    """Delisted capital earns 0% regardless of time fraction."""
 
     def test_basic(self, portfolios_with_delisted, df_year_with_delisted):
         ret, count = _calculate_annual_return(
             portfolios_with_delisted, df_year_with_delisted,
-            delisting_strategy='zero_return'
+            delisting_strategy='zero_return', rebalance_year=2010
         )
         # Live profit: 100*0.10 + 100*0.20 + 100*0.30 = 60
         # Delisted profit: 0
-        # Total value: 400
-        # Return: 60/400 = 0.15
+        # Total value: 400  =>  60/400 = 0.15
         assert ret == pytest.approx(0.15, abs=1e-9)
         assert count == 1
 
     def test_no_delisted(self, df_year_with_delisted):
-        """All-live portfolio should behave the same regardless of strategy."""
         p = Portfolio(name="live_only")
         for t in ['AAPL', 'MSFT', 'GOOGL']:
             p.add_investment(t, 1.0)
         ret, count = _calculate_annual_return(
             [p], df_year_with_delisted,
-            delisting_strategy='zero_return'
+            delisting_strategy='zero_return', rebalance_year=2010
         )
-        # Profit: 10+20+30=60, value=300, return=0.20
         assert ret == pytest.approx(0.20, abs=1e-9)
         assert count == 0
 
 
 class TestHoldCash:
-    """Delisted capital earns risk-free rate."""
+    """Delisted capital earns risk-free rate scaled by time fraction."""
 
-    def test_basic(self, portfolios_with_delisted, df_year_with_delisted):
-        rf = 0.05  # 5%
+    def test_time_adjusted(self, portfolios_with_delisted, df_year_with_delisted):
+        rf = 0.05
+        frac = _july1_fraction()
         ret, count = _calculate_annual_return(
             portfolios_with_delisted, df_year_with_delisted,
-            delisting_strategy='hold_cash',
-            risk_free_rate=rf
+            delisting_strategy='hold_cash', risk_free_rate=rf, rebalance_year=2010
         )
         # Live profit: 60
-        # Delisted profit: 100 * 0.05 = 5
-        # Total: 65 / 400 = 0.1625
-        assert ret == pytest.approx(0.1625, abs=1e-9)
+        # Delisted profit: 100 * 0.05 * fraction
+        # Return: (60 + 100*0.05*frac) / 400
+        expected = (60.0 + 100.0 * rf * frac) / 400.0
+        assert ret == pytest.approx(expected, abs=1e-9)
+        assert count == 1
+
+    def test_fallback_fraction(self, portfolios_with_delisted, df_year_no_delist_date):
+        """Without Delist_Date column, fraction defaults to 0.5."""
+        rf = 0.10
+        ret, count = _calculate_annual_return(
+            portfolios_with_delisted, df_year_no_delist_date,
+            delisting_strategy='hold_cash', risk_free_rate=rf, rebalance_year=2010
+        )
+        expected = (60.0 + 100.0 * rf * 0.5) / 400.0
+        assert ret == pytest.approx(expected, abs=1e-9)
         assert count == 1
 
     def test_zero_rf(self, portfolios_with_delisted, df_year_with_delisted):
         """hold_cash with rf=0 should match zero_return."""
-        ret, count = _calculate_annual_return(
+        ret, _ = _calculate_annual_return(
             portfolios_with_delisted, df_year_with_delisted,
-            delisting_strategy='hold_cash',
-            risk_free_rate=0.0
+            delisting_strategy='hold_cash', risk_free_rate=0.0, rebalance_year=2010
         )
         assert ret == pytest.approx(0.15, abs=1e-9)
-        assert count == 1
 
 
 class TestReinvest:
-    """Delisted capital redistributed pro-rata across surviving positions."""
+    """Delisted capital redistributed pro-rata, scaled by time fraction."""
 
-    def test_basic(self, portfolios_with_delisted, df_year_with_delisted):
+    def test_time_adjusted(self, portfolios_with_delisted, df_year_with_delisted):
+        frac = _july1_fraction()
         ret, count = _calculate_annual_return(
             portfolios_with_delisted, df_year_with_delisted,
-            delisting_strategy='reinvest'
+            delisting_strategy='reinvest', rebalance_year=2010
         )
-        # Live positions: 3 stocks at $100 each, equal weight
-        # Each live stock gets 1/3 of DEAD's $100 capital
-        # Extra profit: (100/300)*100*0.10 + (100/300)*100*0.20 + (100/300)*100*0.30
-        #             = (1/3)*(10+20+30) = 20
-        # Total profit: 60 (live) + 20 (reinvested) = 80
-        # Return: 80 / 400 = 0.20
-        assert ret == pytest.approx(0.20, abs=1e-9)
+        # Live profit from own positions: 60
+        # Live value: 300
+        # Reinvested profit: frac * (100/300) * (live_profit=60) for DEAD's capital
+        #   = frac * (100/300) * 60 = frac * 20
+        # Total: (60 + frac*20) / 400
+        expected = (60.0 + frac * 20.0) / 400.0
+        assert ret == pytest.approx(expected, abs=1e-9)
         assert count == 1
 
     def test_all_delisted(self):
@@ -109,27 +136,27 @@ class TestReinvest:
         df = pd.DataFrame({
             'Ending_Price': [100.0, 100.0],
             'Next-Years_Return': [np.nan, np.nan],
+            'Delist_Date': [pd.Timestamp('2011-06-01'), pd.NaT],
         }, index=['A', 'B'])
         p = Portfolio(name="all_dead")
         p.add_investment('A', 1.0)
         p.add_investment('B', 1.0)
         ret, count = _calculate_annual_return(
-            [p], df, delisting_strategy='reinvest'
+            [p], df, delisting_strategy='reinvest', rebalance_year=2010
         )
         assert ret == pytest.approx(0.0, abs=1e-9)
         assert count == 2
 
 
 class TestEdgeCases:
-    """Edge cases that apply across all strategies."""
+    """Edge cases across all strategies."""
 
     def test_empty_portfolio(self, df_year_with_delisted):
-        """Empty portfolio returns 0."""
         p = Portfolio(name="empty")
         for strategy in ['zero_return', 'hold_cash', 'reinvest']:
             ret, count = _calculate_annual_return(
                 [p], df_year_with_delisted,
-                delisting_strategy=strategy
+                delisting_strategy=strategy, rebalance_year=2010
             )
             assert ret == 0.0
             assert count == 0
@@ -139,20 +166,41 @@ class TestEdgeCases:
         df = pd.DataFrame({
             'Ending_Price': [50.0],
             'Next-Years_Return': [np.nan],
+            'Delist_Date': [pd.Timestamp('2011-10-01')],
         }, index=['DEAD'])
         p = Portfolio(name="solo_dead")
         p.add_investment('DEAD', 2.0)
 
-        # zero_return: 0 profit / 100 total = 0
-        ret, _ = _calculate_annual_return([p], df, delisting_strategy='zero_return')
+        frac = (datetime.date(2011, 12, 31) - datetime.date(2011, 10, 1)).days / 365.0
+
+        # zero_return: always 0
+        ret, _ = _calculate_annual_return([p], df, delisting_strategy='zero_return', rebalance_year=2010)
         assert ret == pytest.approx(0.0, abs=1e-9)
 
-        # hold_cash: 100 * 0.03 / 100 = 0.03
-        ret, _ = _calculate_annual_return(
-            [p], df, delisting_strategy='hold_cash', risk_free_rate=0.03
+        # hold_cash: rf * fraction * value / value = rf * fraction
+        ret, _ = _calculate_annual_return([p], df, delisting_strategy='hold_cash', risk_free_rate=0.03, rebalance_year=2010)
+        assert ret == pytest.approx(0.03 * frac, abs=1e-9)
+
+        # reinvest: no live positions => 0
+        ret, _ = _calculate_annual_return([p], df, delisting_strategy='reinvest', rebalance_year=2010)
+        assert ret == pytest.approx(0.0, abs=1e-9)
+
+    def test_delist_date_dec31_full_year(self):
+        """Stock with Delist_Date on Dec 31 of holding year => fraction ~0."""
+        df = pd.DataFrame({
+            'Ending_Price': [100.0, 100.0],
+            'Next-Years_Return': [20.0, np.nan],
+            'Delist_Date': [pd.NaT, pd.Timestamp('2011-12-31')],
+        }, index=['LIVE', 'DEAD'])
+        p = Portfolio(name="test")
+        p.add_investment('LIVE', 1.0)
+        p.add_investment('DEAD', 1.0)
+
+        # Fraction remaining = 0 days / 365 = 0
+        # hold_cash profit = rf * 0 * 100 = 0, same as zero_return
+        ret, count = _calculate_annual_return(
+            [p], df, delisting_strategy='hold_cash', risk_free_rate=0.05, rebalance_year=2010
         )
-        assert ret == pytest.approx(0.03, abs=1e-9)
-
-        # reinvest: no live positions to redistribute to → 0
-        ret, _ = _calculate_annual_return([p], df, delisting_strategy='reinvest')
-        assert ret == pytest.approx(0.0, abs=1e-9)
+        expected = (100.0 * 0.20 + 0.0) / 200.0  # = 0.10
+        assert ret == pytest.approx(expected, abs=1e-9)
+        assert count == 1

--- a/UnitTests/test_delisting_strategy.py
+++ b/UnitTests/test_delisting_strategy.py
@@ -1,0 +1,158 @@
+"""
+Test suite for delisting strategy functionality.
+Tests the three delisting modes: zero_return, hold_cash, reinvest.
+"""
+import pytest
+import pandas as pd
+import numpy as np
+
+from src.backtest_engine import _calculate_annual_return
+from src.portfolio import Portfolio
+
+
+@pytest.fixture
+def df_year_with_delisted():
+    """
+    Synthetic year-slice with 3 live stocks and 1 delisted (NaN return).
+    All stocks priced at $100 for simple math.
+    """
+    return pd.DataFrame({
+        'Ending_Price': [100.0, 100.0, 100.0, 100.0],
+        'Next-Years_Return': [10.0, 20.0, 30.0, np.nan],
+    }, index=['AAPL', 'MSFT', 'GOOGL', 'DEAD'])
+
+
+@pytest.fixture
+def portfolios_with_delisted():
+    """Portfolio holding 1 share of each of the 4 stocks."""
+    p = Portfolio(name="test")
+    for ticker in ['AAPL', 'MSFT', 'GOOGL', 'DEAD']:
+        p.add_investment(ticker, 1.0)
+    return [p]
+
+
+class TestZeroReturn:
+    """Delisted capital earns 0%."""
+
+    def test_basic(self, portfolios_with_delisted, df_year_with_delisted):
+        ret, count = _calculate_annual_return(
+            portfolios_with_delisted, df_year_with_delisted,
+            delisting_strategy='zero_return'
+        )
+        # Live profit: 100*0.10 + 100*0.20 + 100*0.30 = 60
+        # Delisted profit: 0
+        # Total value: 400
+        # Return: 60/400 = 0.15
+        assert ret == pytest.approx(0.15, abs=1e-9)
+        assert count == 1
+
+    def test_no_delisted(self, df_year_with_delisted):
+        """All-live portfolio should behave the same regardless of strategy."""
+        p = Portfolio(name="live_only")
+        for t in ['AAPL', 'MSFT', 'GOOGL']:
+            p.add_investment(t, 1.0)
+        ret, count = _calculate_annual_return(
+            [p], df_year_with_delisted,
+            delisting_strategy='zero_return'
+        )
+        # Profit: 10+20+30=60, value=300, return=0.20
+        assert ret == pytest.approx(0.20, abs=1e-9)
+        assert count == 0
+
+
+class TestHoldCash:
+    """Delisted capital earns risk-free rate."""
+
+    def test_basic(self, portfolios_with_delisted, df_year_with_delisted):
+        rf = 0.05  # 5%
+        ret, count = _calculate_annual_return(
+            portfolios_with_delisted, df_year_with_delisted,
+            delisting_strategy='hold_cash',
+            risk_free_rate=rf
+        )
+        # Live profit: 60
+        # Delisted profit: 100 * 0.05 = 5
+        # Total: 65 / 400 = 0.1625
+        assert ret == pytest.approx(0.1625, abs=1e-9)
+        assert count == 1
+
+    def test_zero_rf(self, portfolios_with_delisted, df_year_with_delisted):
+        """hold_cash with rf=0 should match zero_return."""
+        ret, count = _calculate_annual_return(
+            portfolios_with_delisted, df_year_with_delisted,
+            delisting_strategy='hold_cash',
+            risk_free_rate=0.0
+        )
+        assert ret == pytest.approx(0.15, abs=1e-9)
+        assert count == 1
+
+
+class TestReinvest:
+    """Delisted capital redistributed pro-rata across surviving positions."""
+
+    def test_basic(self, portfolios_with_delisted, df_year_with_delisted):
+        ret, count = _calculate_annual_return(
+            portfolios_with_delisted, df_year_with_delisted,
+            delisting_strategy='reinvest'
+        )
+        # Live positions: 3 stocks at $100 each, equal weight
+        # Each live stock gets 1/3 of DEAD's $100 capital
+        # Extra profit: (100/300)*100*0.10 + (100/300)*100*0.20 + (100/300)*100*0.30
+        #             = (1/3)*(10+20+30) = 20
+        # Total profit: 60 (live) + 20 (reinvested) = 80
+        # Return: 80 / 400 = 0.20
+        assert ret == pytest.approx(0.20, abs=1e-9)
+        assert count == 1
+
+    def test_all_delisted(self):
+        """If every position is delisted, return should be 0."""
+        df = pd.DataFrame({
+            'Ending_Price': [100.0, 100.0],
+            'Next-Years_Return': [np.nan, np.nan],
+        }, index=['A', 'B'])
+        p = Portfolio(name="all_dead")
+        p.add_investment('A', 1.0)
+        p.add_investment('B', 1.0)
+        ret, count = _calculate_annual_return(
+            [p], df, delisting_strategy='reinvest'
+        )
+        assert ret == pytest.approx(0.0, abs=1e-9)
+        assert count == 2
+
+
+class TestEdgeCases:
+    """Edge cases that apply across all strategies."""
+
+    def test_empty_portfolio(self, df_year_with_delisted):
+        """Empty portfolio returns 0."""
+        p = Portfolio(name="empty")
+        for strategy in ['zero_return', 'hold_cash', 'reinvest']:
+            ret, count = _calculate_annual_return(
+                [p], df_year_with_delisted,
+                delisting_strategy=strategy
+            )
+            assert ret == 0.0
+            assert count == 0
+
+    def test_single_delisted_position(self):
+        """Portfolio with only a single delisted stock."""
+        df = pd.DataFrame({
+            'Ending_Price': [50.0],
+            'Next-Years_Return': [np.nan],
+        }, index=['DEAD'])
+        p = Portfolio(name="solo_dead")
+        p.add_investment('DEAD', 2.0)
+
+        # zero_return: 0 profit / 100 total = 0
+        ret, _ = _calculate_annual_return([p], df, delisting_strategy='zero_return')
+        assert ret == pytest.approx(0.0, abs=1e-9)
+
+        # hold_cash: 100 * 0.03 / 100 = 0.03
+        ret, _ = _calculate_annual_return(
+            [p], df, delisting_strategy='hold_cash', risk_free_rate=0.03
+        )
+        assert ret == pytest.approx(0.03, abs=1e-9)
+
+        # reinvest: no live positions to redistribute to → 0
+        ret, _ = _calculate_annual_return([p], df, delisting_strategy='reinvest')
+        assert ret == pytest.approx(0.0, abs=1e-9)

--- a/app/components/results_tab.py
+++ b/app/components/results_tab.py
@@ -224,6 +224,10 @@ def _render_header_captions(settings: Dict[str, Any]) -> None:
     st.caption(f"**Weighting:** {weighting_str}")
     st.caption(f"**Delisting Strategy:** {delisting_str}")
 
+    delisting_label = {"zero_return": "Zero Return", "hold_cash": "Hold Cash", "reinvest": "Reinvest"}
+    strategy = settings.get('delisting_strategy', 'zero_return')
+    st.caption(f"**Delisting Strategy:** {delisting_label.get(strategy, strategy)}")
+
 def _render_summary_metrics(res: Dict[str, Any], settings: Dict[str, Any]) -> None:
     """
     Calculates and displays core summary metrics for the reporting period.

--- a/app/components/results_tab.py
+++ b/app/components/results_tab.py
@@ -33,6 +33,9 @@ def render_results_tab(results: Dict[str, Any], user_settings: Dict[str, Any]) -
     # 2. Performance Summary
     st.subheader("Performance Summary")
     _render_summary_metrics(results, user_settings)
+    total_delisted = results.get('total_delisted_positions', 0)
+    if total_delisted > 0:
+        st.caption(f"**Delisted positions encountered:** {total_delisted}")
     st.divider()
 
     # 3. Main Growth Plot
@@ -208,9 +211,18 @@ def _render_header_captions(settings: Dict[str, Any]) -> None:
     saved_dirs = st.session_state.get('factor_directions', {})
     factors_str = ", ".join([f"{f} ({saved_dirs.get(f, 'top')})" for f in selected_factors])
     weighting_str = "Market Cap Weighted" if settings.get('use_market_cap_weight') else "Equal Weighted"
-    
+    delisting_labels = {
+        "zero_return": "Zero Return",
+        "hold_cash": "Hold Cash (risk-free rate)",
+        "reinvest": "Reinvest (pro-rata)"
+    }
+    delisting_str = delisting_labels.get(
+        settings.get('delisting_strategy', 'zero_return'), 'Zero Return'
+    )
+
     st.caption(f"**Factors:** {factors_str}")
     st.caption(f"**Weighting:** {weighting_str}")
+    st.caption(f"**Delisting Strategy:** {delisting_str}")
 
 def _render_summary_metrics(res: Dict[str, Any], settings: Dict[str, Any]) -> None:
     """

--- a/app/components/results_tab.py
+++ b/app/components/results_tab.py
@@ -224,10 +224,6 @@ def _render_header_captions(settings: Dict[str, Any]) -> None:
     st.caption(f"**Weighting:** {weighting_str}")
     st.caption(f"**Delisting Strategy:** {delisting_str}")
 
-    delisting_label = {"zero_return": "Zero Return", "hold_cash": "Hold Cash", "reinvest": "Reinvest"}
-    strategy = settings.get('delisting_strategy', 'zero_return')
-    st.caption(f"**Delisting Strategy:** {delisting_label.get(strategy, strategy)}")
-
 def _render_summary_metrics(res: Dict[str, Any], settings: Dict[str, Any]) -> None:
     """
     Calculates and displays core summary metrics for the reporting period.

--- a/app/components/sidebar.py
+++ b/app/components/sidebar.py
@@ -71,7 +71,20 @@ def render_sidebar(sector_options: List[str]) -> Dict[str, Any]:
         )
 
         st.divider()
-        
+
+        # Delisting Strategy
+        st.subheader("Delisting Strategy")
+        delisting_strategy = st.radio(
+            "How to treat delisted positions:",
+            options=["Zero Return", "Hold Cash", "Reinvest"],
+            index=0,
+            help="Zero Return: 0% on delisted capital. Hold Cash: earn risk-free rate (time-adjusted). Reinvest: redistribute pro-rata to survivors."
+        )
+        delisting_map = {"Zero Return": "zero_return", "Hold Cash": "hold_cash", "Reinvest": "reinvest"}
+        delisting_strategy_key = delisting_map[delisting_strategy]
+
+        st.divider()
+
         # Sector Exposure Configuration
         st.subheader("Sector Selection")
         sector_filter_enabled = st.checkbox("Enable Sector Filter", value=False)
@@ -137,5 +150,6 @@ def render_sidebar(sector_options: List[str]) -> Dict[str, Any]:
         "sector_filter_enabled": sector_filter_enabled,
         "start_year": start_year,
         "end_year": end_year,
-        "initial_aum": initial_aum
+        "initial_aum": initial_aum,
+        "delisting_strategy": delisting_strategy_key
     }

--- a/app/components/sidebar.py
+++ b/app/components/sidebar.py
@@ -49,7 +49,27 @@ def render_sidebar(sector_options: List[str]) -> Dict[str, Any]:
         
         if use_market_cap_weight:
             st.info("Portfolio will be weighted by market capitalization, aligning with the Russell 2000 methodology.")
-        
+
+        st.divider()
+
+        # Delisting Strategy
+        st.subheader("Delisting Strategy")
+        delisting_strategy = st.radio(
+            "Handle delisted positions:",
+            options=["zero_return", "hold_cash", "reinvest"],
+            format_func=lambda x: {
+                "zero_return": "Zero Return (default)",
+                "hold_cash": "Hold Cash (earn risk-free rate)",
+                "reinvest": "Reinvest (redistribute pro-rata)"
+            }[x],
+            index=0,
+            help=(
+                "Zero Return: delisted stocks earn 0% (legacy). "
+                "Hold Cash: delisted capital earns the risk-free rate. "
+                "Reinvest: delisted capital is redistributed pro-rata across surviving positions."
+            )
+        )
+
         st.divider()
         
         # Sector Exposure Configuration
@@ -112,6 +132,7 @@ def render_sidebar(sector_options: List[str]) -> Dict[str, Any]:
     return {
         "restrict_fossil_fuels": restrict_fossil_fuels,
         "use_market_cap_weight": use_market_cap_weight,
+        "delisting_strategy": delisting_strategy,
         "selected_sectors": selected_sectors if sector_filter_enabled else None,
         "sector_filter_enabled": sector_filter_enabled,
         "start_year": start_year,

--- a/app/components/sidebar.py
+++ b/app/components/sidebar.py
@@ -55,26 +55,6 @@ def render_sidebar(sector_options: List[str]) -> Dict[str, Any]:
         # Delisting Strategy
         st.subheader("Delisting Strategy")
         delisting_strategy = st.radio(
-            "Handle delisted positions:",
-            options=["zero_return", "hold_cash", "reinvest"],
-            format_func=lambda x: {
-                "zero_return": "Zero Return (default)",
-                "hold_cash": "Hold Cash (earn risk-free rate)",
-                "reinvest": "Reinvest (redistribute pro-rata)"
-            }[x],
-            index=0,
-            help=(
-                "Zero Return: delisted stocks earn 0% (legacy). "
-                "Hold Cash: delisted capital earns the risk-free rate. "
-                "Reinvest: delisted capital is redistributed pro-rata across surviving positions."
-            )
-        )
-
-        st.divider()
-
-        # Delisting Strategy
-        st.subheader("Delisting Strategy")
-        delisting_strategy = st.radio(
             "How to treat delisted positions:",
             options=["Zero Return", "Hold Cash", "Reinvest"],
             index=0,
@@ -145,7 +125,6 @@ def render_sidebar(sector_options: List[str]) -> Dict[str, Any]:
     return {
         "restrict_fossil_fuels": restrict_fossil_fuels,
         "use_market_cap_weight": use_market_cap_weight,
-        "delisting_strategy": delisting_strategy,
         "selected_sectors": selected_sectors if sector_filter_enabled else None,
         "sector_filter_enabled": sector_filter_enabled,
         "start_year": start_year,

--- a/app/streamlit_utils.py
+++ b/app/streamlit_utils.py
@@ -153,7 +153,8 @@ def run_backtest_logic(user_settings: Dict[str, Any],
             initial_aum=user_settings['initial_aum'],
             benchmark_index=user_settings.get('benchmark_index', 1),
             top_pct=user_settings.get('top_pct', 10.0),
-            use_market_cap_weight=user_settings.get('use_market_cap_weight', False)
+            use_market_cap_weight=user_settings.get('use_market_cap_weight', False),
+            delisting_strategy=user_settings.get('delisting_strategy', 'zero_return')
         )
 
         # Build a ranked list for the most recent rebalance year used by the backtest loop.

--- a/src/backtest_engine.py
+++ b/src/backtest_engine.py
@@ -152,34 +152,53 @@ def calculate_holdings(
                 
     return portfolio
 
-def rebalance_portfolio(data: pd.DataFrame, factors: List[str], factor_directions: Dict[str, str], 
-                        start_year: int, end_year: int, initial_aum: float, 
-                        benchmark_index: int = 1, top_pct: float = 10.0, 
-                        use_market_cap_weight: bool = False) -> Dict[str, Any]:
-    """Executes simulation using a filtered working copy of the master data."""
-    
+def rebalance_portfolio(data: pd.DataFrame, factors: List[str], factor_directions: Dict[str, str],
+                        start_year: int, end_year: int, initial_aum: float,
+                        benchmark_index: int = 1, top_pct: float = 10.0,
+                        use_market_cap_weight: bool = False,
+                        delisting_strategy: str = 'zero_return') -> Dict[str, Any]:
+    """Executes simulation using a filtered working copy of the master data.
+
+    Args:
+        delisting_strategy: how to treat delisted positions. One of
+            'zero_return' (default/legacy), 'hold_cash', or 'reinvest'.
+    """
+
     # ON-THE-FLY FILTERING: Apply constraints to a copy
     exclude_fossil = st.session_state.get('exclude_fossil_fuels', False)
     selected_sectors = st.session_state.get('selected_sectors', [])
-    
+
     working_data = filter_universe(data, exclude_fossil, selected_sectors)
-    
+
     aum = initial_aum
     portfolio_values = [aum]
     portfolio_returns = []
+    total_delisted = 0
+
+    # Pre-fetch risk-free rates for hold_cash strategy
+    rf_by_year = {}
+    if delisting_strategy == 'hold_cash':
+        rf_full = get_benchmark_list(4, start_year, end_year)
+        for i, yr in enumerate(range(start_year, end_year)):
+            rf_by_year[yr] = rf_full[i] if i < len(rf_full) else 0.0
 
     # Simulation Loop
     for year in range(start_year, end_year):
         df_year = working_data[working_data['Year'] == year].set_index('Ticker')
         if df_year.empty: continue
-            
+
         factor_aum = aum / len(factors)
         yearly_components = [
             calculate_holdings(df_year, f, factor_aum, (factor_directions.get(f) == 'top'), top_pct, use_market_cap_weight)
             for f in factors
         ]
 
-        year_ret = _calculate_annual_return(yearly_components, df_year)
+        year_ret, delisted_count = _calculate_annual_return(
+            yearly_components, df_year,
+            delisting_strategy=delisting_strategy,
+            risk_free_rate=rf_by_year.get(year, 0.0)
+        )
+        total_delisted += delisted_count
         portfolio_returns.append(year_ret)
         aum *= (1 + year_ret)
         portfolio_values.append(aum)
@@ -189,29 +208,78 @@ def rebalance_portfolio(data: pd.DataFrame, factors: List[str], factor_direction
     bench_rets = np.array(get_benchmark_list(benchmark_index, start_year + 1, end_year + 1)) / 100.0
     growth_rets = np.array(get_benchmark_list(2, start_year + 1, end_year + 1)) / 100.0
     value_rets = np.array(get_benchmark_list(3, start_year + 1, end_year + 1)) / 100.0
-    
+
     min_len = min(len(portfolio_returns), len(bench_rets), len(growth_rets), len(value_rets))
-    
+
     return compute_comprehensive_metrics(
-        np.array(portfolio_returns[:min_len]), bench_rets[:min_len], 
-        growth_rets[:min_len], value_rets[:min_len], rf_rates[:min_len], 
-        portfolio_values[:min_len + 1], start_year, start_year + min_len
+        np.array(portfolio_returns[:min_len]), bench_rets[:min_len],
+        growth_rets[:min_len], value_rets[:min_len], rf_rates[:min_len],
+        portfolio_values[:min_len + 1], start_year, start_year + min_len,
+        delisting_strategy=delisting_strategy,
+        total_delisted_positions=total_delisted
     )
 
-def _calculate_annual_return(portfolios: List[Portfolio], df_year: pd.DataFrame) -> float:
-    """Realized return logic based on SQL 'Next-Years_Return'."""
-    total_val, total_profit = 0.0, 0.0
+def _calculate_annual_return(portfolios: List[Portfolio], df_year: pd.DataFrame,
+                             delisting_strategy: str = 'zero_return',
+                             risk_free_rate: float = 0.0) -> Tuple[float, int]:
+    """Realized return logic based on SQL 'Next-Years_Return'.
+
+    Args:
+        delisting_strategy: how to handle positions whose stock was delisted
+            (NaN in Next-Years_Return) during the holding period:
+            - 'zero_return': treat as 0% return (legacy behaviour).
+            - 'hold_cash': earn the risk-free rate on delisted capital.
+            - 'reinvest': redistribute delisted capital pro-rata across
+              surviving positions.
+        risk_free_rate: annual risk-free rate as a decimal (e.g. 0.02).
+            Only used when delisting_strategy='hold_cash'.
+
+    Returns:
+        (annual_return, delisted_count)
+    """
+    live_positions = []      # (position_value, return)
+    delisted_value = 0.0
+    delisted_count = 0
+
     for p in portfolios:
         for inv in p.investments:
             t = inv['ticker']
-            if t in df_year.index:
-                price = df_year.loc[t, 'Ending_Price']
-                ret_val = df_year.loc[t, 'Next-Years_Return']
-                ret = (ret_val / 100.0) if not pd.isna(ret_val) else 0.0
-                pos_val = inv['number_of_shares'] * price
-                total_val += pos_val
-                total_profit += pos_val * ret
-    return total_profit / total_val if total_val > 0 else 0.0
+            if t not in df_year.index:
+                continue
+            price = df_year.loc[t, 'Ending_Price']
+            if pd.isna(price) or price <= 0:
+                continue
+            pos_val = inv['number_of_shares'] * price
+            ret_val = df_year.loc[t, 'Next-Years_Return']
+
+            if pd.isna(ret_val):
+                delisted_value += pos_val
+                delisted_count += 1
+            else:
+                live_positions.append((pos_val, ret_val / 100.0))
+
+    live_value = sum(pv for pv, _ in live_positions)
+    total_val = live_value + delisted_value
+
+    if total_val == 0:
+        return 0.0, 0
+
+    live_profit = sum(pv * ret for pv, ret in live_positions)
+
+    if delisting_strategy == 'hold_cash':
+        delisted_profit = risk_free_rate * delisted_value
+    elif delisting_strategy == 'reinvest':
+        if live_value > 0:
+            delisted_profit = sum(
+                (pv / live_value) * delisted_value * ret
+                for pv, ret in live_positions
+            )
+        else:
+            delisted_profit = 0.0
+    else:  # 'zero_return'
+        delisted_profit = 0.0
+
+    return (live_profit + delisted_profit) / total_val, delisted_count
 
 
 def run_cohort_comparison(data: pd.DataFrame, 

--- a/src/backtest_engine.py
+++ b/src/backtest_engine.py
@@ -160,8 +160,7 @@ def rebalance_portfolio(data: pd.DataFrame, factors: List[str], factor_direction
     """Executes simulation using a filtered working copy of the master data.
 
     Args:
-        delisting_strategy: how to treat delisted positions. One of
-            'zero_return' (default/legacy), 'hold_cash', or 'reinvest'.
+        delisting_strategy: 'zero_return', 'hold_cash', or 'reinvest'.
     """
 
     # ON-THE-FLY FILTERING: Apply constraints to a copy
@@ -196,7 +195,8 @@ def rebalance_portfolio(data: pd.DataFrame, factors: List[str], factor_direction
         year_ret, delisted_count = _calculate_annual_return(
             yearly_components, df_year,
             delisting_strategy=delisting_strategy,
-            risk_free_rate=rf_by_year.get(year, 0.0)
+            risk_free_rate=rf_by_year.get(year, 0.0),
+            rebalance_year=year
         )
         total_delisted += delisted_count
         portfolio_returns.append(year_ret)
@@ -211,34 +211,37 @@ def rebalance_portfolio(data: pd.DataFrame, factors: List[str], factor_direction
 
     min_len = min(len(portfolio_returns), len(bench_rets), len(growth_rets), len(value_rets))
 
-    return compute_comprehensive_metrics(
+    results = compute_comprehensive_metrics(
         np.array(portfolio_returns[:min_len]), bench_rets[:min_len],
         growth_rets[:min_len], value_rets[:min_len], rf_rates[:min_len],
-        portfolio_values[:min_len + 1], start_year, start_year + min_len,
-        delisting_strategy=delisting_strategy,
-        total_delisted_positions=total_delisted
+        portfolio_values[:min_len + 1], start_year, start_year + min_len
     )
+    results['delisting_strategy'] = delisting_strategy
+    results['total_delisted_positions'] = total_delisted
+    return results
 
 def _calculate_annual_return(portfolios: List[Portfolio], df_year: pd.DataFrame,
                              delisting_strategy: str = 'zero_return',
-                             risk_free_rate: float = 0.0) -> Tuple[float, int]:
-    """Realized return logic based on SQL 'Next-Years_Return'.
+                             risk_free_rate: float = 0.0,
+                             rebalance_year: int = 0) -> Tuple[float, int]:
+    """Realized return logic with time-adjusted delisting handling.
 
     Args:
-        delisting_strategy: how to handle positions whose stock was delisted
-            (NaN in Next-Years_Return) during the holding period:
-            - 'zero_return': treat as 0% return (legacy behaviour).
-            - 'hold_cash': earn the risk-free rate on delisted capital.
-            - 'reinvest': redistribute delisted capital pro-rata across
-              surviving positions.
-        risk_free_rate: annual risk-free rate as a decimal (e.g. 0.02).
-            Only used when delisting_strategy='hold_cash'.
+        delisting_strategy: 'zero_return', 'hold_cash', or 'reinvest'.
+        risk_free_rate: annual RF rate as decimal (e.g. 0.02).
+        rebalance_year: formation year; holding period is rebalance_year+1.
 
     Returns:
         (annual_return, delisted_count)
     """
-    live_positions = []      # (position_value, return)
+    import datetime
+
+    holding_end = datetime.date(rebalance_year + 1, 12, 31)
+    has_delist_date = 'Delist_Date' in df_year.columns
+
+    live_positions = []       # (position_value, return)
     delisted_value = 0.0
+    delisted_fractions = []   # time-fraction remaining after delist
     delisted_count = 0
 
     for p in portfolios:
@@ -253,7 +256,17 @@ def _calculate_annual_return(portfolios: List[Portfolio], df_year: pd.DataFrame,
             ret_val = df_year.loc[t, 'Next-Years_Return']
 
             if pd.isna(ret_val):
+                # Compute fraction of holding year remaining after delist
+                fraction = 0.5  # default when date unknown
+                if has_delist_date:
+                    delist_dt = df_year.loc[t, 'Delist_Date']
+                    if pd.notna(delist_dt):
+                        if hasattr(delist_dt, 'date'):
+                            delist_dt = delist_dt.date()
+                        remaining_days = max(0, (holding_end - delist_dt).days)
+                        fraction = remaining_days / 365.0
                 delisted_value += pos_val
+                delisted_fractions.append((pos_val, fraction))
                 delisted_count += 1
             else:
                 live_positions.append((pos_val, ret_val / 100.0))
@@ -267,13 +280,15 @@ def _calculate_annual_return(portfolios: List[Portfolio], df_year: pd.DataFrame,
     live_profit = sum(pv * ret for pv, ret in live_positions)
 
     if delisting_strategy == 'hold_cash':
-        delisted_profit = risk_free_rate * delisted_value
+        delisted_profit = sum(
+            risk_free_rate * frac * pv for pv, frac in delisted_fractions
+        )
     elif delisting_strategy == 'reinvest':
         if live_value > 0:
             delisted_profit = sum(
-                (pv / live_value) * delisted_value * ret
-                for pv, ret in live_positions
-            )
+                frac * (pv / live_value) * sum(lv * lr for lv, lr in live_positions)
+                for pv, frac in delisted_fractions
+            ) if delisted_fractions else 0.0
         else:
             delisted_profit = 0.0
     else:  # 'zero_return'

--- a/src/backtest_engine.py
+++ b/src/backtest_engine.py
@@ -238,10 +238,12 @@ def _calculate_annual_return(portfolios: List[Portfolio], df_year: pd.DataFrame,
 
     holding_end = datetime.date(rebalance_year + 1, 12, 31)
     has_delist_date = 'Delist_Date' in df_year.columns
+    has_delist_price = 'Delist_Price' in df_year.columns
 
     live_positions = []       # (position_value, return)
-    delisted_value = 0.0
-    delisted_fractions = []   # time-fraction remaining after delist
+    delisted_pre_profit = 0.0 # profit earned before delisting
+    delisted_post_capital = [] # (capital_at_delist, fraction) for post-delist strategies
+    delisted_value = 0.0      # total position value at formation
     delisted_count = 0
 
     for p in portfolios:
@@ -256,7 +258,16 @@ def _calculate_annual_return(portfolios: List[Portfolio], df_year: pd.DataFrame,
             ret_val = df_year.loc[t, 'Next-Years_Return']
 
             if pd.isna(ret_val):
-                # Compute fraction of holding year remaining after delist
+                # Pre-delist return: actual price change from formation to delisting
+                partial_return = 0.0
+                if has_delist_price:
+                    dp = df_year.loc[t, 'Delist_Price']
+                    if pd.notna(dp) and dp >= 0:
+                        partial_return = (dp / price) - 1.0
+                delisted_pre_profit += pos_val * partial_return
+                capital_at_delist = pos_val * (1.0 + partial_return)
+
+                # Post-delist fraction: time remaining in holding year
                 fraction = 0.5  # default when date unknown
                 if has_delist_date:
                     delist_dt = df_year.loc[t, 'Delist_Date']
@@ -266,7 +277,7 @@ def _calculate_annual_return(portfolios: List[Portfolio], df_year: pd.DataFrame,
                         remaining_days = max(0, (holding_end - delist_dt).days)
                         fraction = remaining_days / 365.0
                 delisted_value += pos_val
-                delisted_fractions.append((pos_val, fraction))
+                delisted_post_capital.append((capital_at_delist, fraction))
                 delisted_count += 1
             else:
                 live_positions.append((pos_val, ret_val / 100.0))
@@ -280,21 +291,23 @@ def _calculate_annual_return(portfolios: List[Portfolio], df_year: pd.DataFrame,
     live_profit = sum(pv * ret for pv, ret in live_positions)
 
     if delisting_strategy == 'hold_cash':
-        delisted_profit = sum(
-            risk_free_rate * frac * pv for pv, frac in delisted_fractions
+        post_profit = sum(
+            risk_free_rate * frac * cap for cap, frac in delisted_post_capital
         )
     elif delisting_strategy == 'reinvest':
         if live_value > 0:
-            delisted_profit = sum(
-                frac * (pv / live_value) * sum(lv * lr for lv, lr in live_positions)
-                for pv, frac in delisted_fractions
-            ) if delisted_fractions else 0.0
+            live_return = sum(pv * ret for pv, ret in live_positions) / live_value
+            post_profit = sum(
+                frac * cap * live_return
+                for cap, frac in delisted_post_capital
+            ) if delisted_post_capital else 0.0
         else:
-            delisted_profit = 0.0
+            post_profit = 0.0
     else:  # 'zero_return'
-        delisted_profit = 0.0
+        post_profit = 0.0
 
-    return (live_profit + delisted_profit) / total_val, delisted_count
+    total_profit = live_profit + delisted_pre_profit + post_profit
+    return total_profit / total_val, delisted_count
 
 
 def run_cohort_comparison(data: pd.DataFrame, 

--- a/src/performance_metrics.py
+++ b/src/performance_metrics.py
@@ -11,9 +11,7 @@ from typing import Dict, List, Any
 
 def compute_comprehensive_metrics(p_ret: np.ndarray, b_ret: np.ndarray, g_ret: np.ndarray,
                                  v_ret: np.ndarray, rf: np.ndarray,
-                                 p_vals: List[float], start: int, end: int,
-                                 delisting_strategy: str = 'zero_return',
-                                 total_delisted_positions: int = 0) -> Dict[str, Any]:
+                                 p_vals: List[float], start: int, end: int) -> Dict[str, Any]:
     """Calculates risk/return metrics across all benchmarks."""
     
     # Excess Returns
@@ -91,7 +89,5 @@ def compute_comprehensive_metrics(p_ret: np.ndarray, b_ret: np.ndarray, g_ret: n
         'information_ratio': get_ir(p_ret, b_ret),
         'information_ratio_growth': get_ir(p_ret, g_ret),
         'information_ratio_value': get_ir(p_ret, v_ret),
-        'risk_free_rate_source': "FRED 4 Week T-Bill (Oct 1)",
-        'delisting_strategy': delisting_strategy,
-        'total_delisted_positions': total_delisted_positions
+        'risk_free_rate_source': "FRED 4 Week T-Bill (Oct 1)"
     }

--- a/src/performance_metrics.py
+++ b/src/performance_metrics.py
@@ -9,9 +9,11 @@ import numpy as np
 import pandas as pd
 from typing import Dict, List, Any
 
-def compute_comprehensive_metrics(p_ret: np.ndarray, b_ret: np.ndarray, g_ret: np.ndarray, 
-                                 v_ret: np.ndarray, rf: np.ndarray, 
-                                 p_vals: List[float], start: int, end: int) -> Dict[str, Any]:
+def compute_comprehensive_metrics(p_ret: np.ndarray, b_ret: np.ndarray, g_ret: np.ndarray,
+                                 v_ret: np.ndarray, rf: np.ndarray,
+                                 p_vals: List[float], start: int, end: int,
+                                 delisting_strategy: str = 'zero_return',
+                                 total_delisted_positions: int = 0) -> Dict[str, Any]:
     """Calculates risk/return metrics across all benchmarks."""
     
     # Excess Returns
@@ -89,5 +91,7 @@ def compute_comprehensive_metrics(p_ret: np.ndarray, b_ret: np.ndarray, g_ret: n
         'information_ratio': get_ir(p_ret, b_ret),
         'information_ratio_growth': get_ir(p_ret, g_ret),
         'information_ratio_value': get_ir(p_ret, v_ret),
-        'risk_free_rate_source': "FRED 4 Week T-Bill (Oct 1)"
+        'risk_free_rate_source': "FRED 4 Week T-Bill (Oct 1)",
+        'delisting_strategy': delisting_strategy,
+        'total_delisted_positions': total_delisted_positions
     }

--- a/src/supabase_client.py
+++ b/src/supabase_client.py
@@ -75,7 +75,7 @@ class SupabaseManager:
         # Merge delisting dates from last_price_mapping for time-adjusted strategies
         lpm = self.fetch_last_price_mapping()
         if not lpm.empty:
-            df = df.merge(lpm[['Ticker-Region', 'Delist_Date']], on='Ticker-Region', how='left')
+            df = df.merge(lpm[['Ticker-Region', 'Delist_Date', 'Delist_Price']], on='Ticker-Region', how='left')
 
         return df
 

--- a/src/supabase_client.py
+++ b/src/supabase_client.py
@@ -70,7 +70,42 @@ class SupabaseManager:
             logger.warning("Ingestion process completed but returned an empty dataset.")
             return df
 
-        return self._standardize_dataframe(df)
+        df = self._standardize_dataframe(df)
+
+        # Merge delisting dates from last_price_mapping for time-adjusted strategies
+        lpm = self.fetch_last_price_mapping()
+        if not lpm.empty:
+            df = df.merge(lpm[['Ticker-Region', 'Delist_Date']], on='Ticker-Region', how='left')
+
+        return df
+
+    def fetch_last_price_mapping(self) -> pd.DataFrame:
+        """Retrieves the last_price_mapping table containing delisting dates and prices."""
+        page_size = 1000
+        offset = 0
+        all_rows = []
+
+        try:
+            while True:
+                response = self.client.table('last_price_mapping').select('*').range(offset, offset + page_size - 1).execute()
+                batch = response.data if hasattr(response, 'data') else []
+                if not batch:
+                    break
+                all_rows.extend(batch)
+                if len(batch) < page_size:
+                    break
+                offset += page_size
+        except Exception as e:
+            logger.error(f"Failed to fetch last_price_mapping: {str(e)}")
+            return pd.DataFrame()
+
+        if not all_rows:
+            return pd.DataFrame()
+
+        lpm = pd.DataFrame(all_rows)
+        lpm = lpm.rename(columns={'ticker': 'Ticker-Region', 'last_date': 'Delist_Date', 'last_price': 'Delist_Price'})
+        lpm['Delist_Date'] = pd.to_datetime(lpm['Delist_Date'], errors='coerce')
+        return lpm
 
     def _standardize_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
         """


### PR DESCRIPTION
### What's new
 - Three delisting strategies for NaN-return positions: zero return, hold cash (RF), reinvest (pro-rata to survivors)
 - Time-adjusted using last_price_mapping table from Supabase — RF and reinvestment scaled by fraction of year remaining after delist date (95%
  coverage; missing dates default to mid-year)
- Pre-delist partial return computed from last_price / Ending_Price, so a stock that gained 50% before delisting carries that into the
  post-delist capital base
- Sidebar radio selector, results tab display, 35 passing unit tests

## How review feedback was addressed

- risk_free_rate * delisted_value now correctly scaled by time fraction (@kelvinchi02)
- last_price_mapping table used for both delist date and delist price

 ## Recommended test plan

- pytest UnitTests/test_delisting_strategy.py UnitTests/test_calculate_holdings.py -v (35/35)
- Verify sidebar shows "Delisting Strategy" radio with three options
- Run backtest with each strategy and confirm different final portfolio values
- Results header shows selected strategy; delisted count shown when > 0
