### PR TITLE
Fix factor-name/DB-column mismatch and add cohort style series

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@ An interactive factor-investing toolkit with a clean Streamlit UI, Supabase data
 ## Use the App
 
 - Hosted: Share your Streamlit Community Cloud app URL. Users only need the link to use the app.
-- Password: Set a secret named `password` in your app’s Settings → Secrets. Locally you can use `.streamlit/secrets.toml`.
+- Password: Set a secret named `password` in your app's Settings -> Secrets.
+- Supabase: Set `SUPABASE_URL` and `SUPABASE_KEY` in Streamlit secrets for cloud deploys (or `.env` for local runs).
 
 Example secrets (TOML):
 ```
 password = "your-strong-password"
+SUPABASE_URL = "https://your-project.supabase.co"
+SUPABASE_KEY = "your-anon-public-key"
 ```
 
 ## Quick Start (Local)
@@ -27,29 +30,36 @@ Then open http://localhost:8501
 
 - Clean factor selection (13 core factors: Momentum, Value, Quality, Growth, Profitability)
 - ESG exclusion (fossil fuel filter)
-- Sector filtering (5-sector classification)
+- Sector filtering (configurable sector universe)
 - Supabase data loading with column normalization
-- Annual rebalancing backtest (2002–2023)
-- Benchmark comparison vs Russell 2000
+- Annual rebalancing backtest (configurable period, currently 2002-2024 in UI)
+- Benchmark comparison vs Russell 2000, Growth, and Value
 - Performance metrics: CAGR, yearly returns, drawdown, Sharpe, Information Ratio, win rate
-- Downloadable performance table
+- Ranked-stock table and top-vs-bottom cohort analysis
 
 ## Project Layout
 
 ```
 Factor-Lake/
-├── app/                    # Streamlit entrypoints
-│   └── streamlit_app.py    # Main UI
+├── app/                    # Streamlit app and UI components
+│   ├── streamlit_app.py    # Main entrypoint
+│   ├── streamlit_utils.py  # Session state / orchestration helpers
+│   ├── streamlit_config.py # Factor and UI metadata
+│   └── components/         # Sidebar, factor selection, results, about
 ├── src/                    # Library & core logic
-│   ├── market_object.py
-│   ├── calculate_holdings.py
-│   ├── factor_function.py
+│   ├── backtest_engine.py
+│   ├── benchmarks.py
+│   ├── performance_metrics.py
 │   ├── portfolio.py
-│   ├── sector_selection.py
+│   ├── portfolio_filters.py
+│   ├── factor_registry.py
+│   ├── factor_utils.py
+│   ├── factors_doc.py
 │   ├── supabase_client.py
 │   └── ...
 ├── Visualizations/         # Plot helpers
-├── UnitTests/              # Pytest suite
+├── UnitTests/              # Unit test suite (default pytest target)
+├── IntegrationTests/       # Integration tests (run explicitly)
 ├── scripts/                # CI / helper scripts
 ├── DOCS/                   # Supplementary documentation
 ├── requirements.txt
@@ -60,29 +70,47 @@ Factor-Lake/
 
 Always import from `src`:
 ```python
-from src.market_object import load_data
-from src.calculate_holdings import rebalance_portfolio
+from src.backtest_engine import rebalance_portfolio
+from src.portfolio import Portfolio
+from src.factor_registry import get_factor_column
 ```
 
 ## Documentation
 
-- `DOCS/STREAMLIT_README.md` – UI overview
-- `DOCS/STREAMLIT_STYLING_GUIDE.md` – Styling / customization
-- `DOCS/SUPABASE_SETUP.md` – Environment & table notes
-- `DOCS/REORGANIZATION_SUMMARY.md` – Refactor rationale
+- `DOCS/index.md` - Documentation home
+- `DOCS/CONTRIBUTING.md` - Contribution guidelines
+- `DOCS/DEPLOYMENT.md` - Streamlit Community Cloud deployment
+- `DOCS/SUPABASE_SETUP.md` - Environment and credentials setup
+- `DOCS/STREAMLIT_STYLING_GUIDE.md` - Styling and UI customization
+- `DOCS/Bandit & Safety.md` - Security scanning notes
+- `DOCS/REORGANIZATION_SUMMARY.md` - Historical refactor summary (contains legacy context)
 
 ## Deployment
 
 For detailed deployment instructions (Streamlit Community Cloud, secrets management, and troubleshooting), see `DOCS/DEPLOYMENT.md`.
 
+Run locally with:
+
+```pwsh
+python -m streamlit run .\app\streamlit_app.py
+```
+
 ## Contributing
 
 1. Create a feature branch from `main`.
-2. Add/modify tests in `UnitTests/` or `tests/`.
-3. Run `pytest -q` to verify.
-4. Submit a PR describing UX/data impacts.
+2. Add/modify tests in `UnitTests/` and/or `IntegrationTests/`.
+3. Run unit tests with `pytest` (defaults to `UnitTests/` via `pytest.ini`).
+4. Run integration tests explicitly when needed:
 
-## License
+```pwsh
+pytest IntegrationTests/ -m integration -v
+```
 
-See `LICENSE` for details.
+5. Optionally use the helper runner:
+
+```pwsh
+python .\scripts\run_tests.py all
+```
+
+6. Submit a PR describing UX/data impacts.
 

--- a/Visualizations/top_bottom_portfolio_plot.py
+++ b/Visualizations/top_bottom_portfolio_plot.py
@@ -2,7 +2,7 @@
 PROJECT: Factor-Lake Portfolio Analysis
 MODULE: Visualizations/top_bottom_portfolio_plot.py
 PURPOSE: Institutional-grade cohort spread analysis visualization.
-VERSION: 2.1.1
+VERSION: 2.1.2
 """
 
 import matplotlib.pyplot as plt
@@ -14,6 +14,8 @@ def plot_top_bottom_percent(
     percent: float = 10.0,
     show_bottom: bool = True,
     benchmark_returns: Optional[List[float]] = None,
+    growth_returns: Optional[List[float]] = None,
+    value_returns: Optional[List[float]] = None,
     benchmark_label: str = 'Russell 2000',
     initial_investment: float = 1000000.0,
     baseline_portfolio_values: Optional[List[float]] = None,
@@ -22,44 +24,53 @@ def plot_top_bottom_percent(
 ) -> plt.Figure:
     """
     Constructs a wealth-index chart comparing performance of top and bottom cohorts.
-    
-    This visualization identifies the predictive power of selected factors by 
-    plotting the divergence between the highest and lowest ranked stocks.
     """
     fig, ax = plt.subplots(figsize=(12, 6), dpi=100)
 
-    # 1. Benchmark Trajectory Construction
-    if benchmark_returns is not None:
-        bench_vals = [initial_investment]
-        for ret in benchmark_returns:
-            # Handle both percentage (8.5) and decimal (0.085) formats
+    def _get_trajectory(series: Optional[List[float]]) -> Optional[List[float]]:
+        if series is None:
+            return None
+
+        if len(series) == 0:
+            return None
+
+        # If the series already looks like wealth levels (same length as years
+        # and starts at the initial investment), plot it directly.
+        if (
+            len(series) == len(years)
+            and abs(float(series[0]) - float(initial_investment)) <= max(1.0, 0.001 * float(initial_investment))
+        ):
+            return series[:len(years)]
+
+        vals = [initial_investment]
+        for ret in series:
             multiplier = (ret / 100.0) if abs(ret) > 1.0 else ret
-            bench_vals.append(bench_vals[-1] * (1 + multiplier))
-        
-        if len(bench_vals) >= len(years):
-            ax.plot(years, bench_vals[:len(years)], label=benchmark_label, color='#d62728', 
-                    linestyle='--', linewidth=1.5, alpha=0.7)
+            vals.append(vals[-1] * (1 + multiplier))
+        return vals[:len(years)]
+
+    # 1. Index Trajectories (Benchmark, Growth, Value)
+    indices = [
+        (benchmark_returns, benchmark_label, '#d62728', '--', None),
+        (growth_returns, 'Growth Index', '#ff7f0e', ':', 'D'),
+        (value_returns, 'Value Index', '#17becf', ':', 's')
+    ]
+
+    for rets, label, color, style, marker in indices:
+        vals = _get_trajectory(rets)
+        if vals and len(vals) == len(years):
+            ax.plot(years, vals, label=label, color=color, linestyle=style, 
+                    marker=marker, markersize=3, linewidth=1.2, alpha=0.6)
 
     # 2. Bottom Cohort (Lower Visual Weight)
     if show_bottom and precomputed_bot is not None:
-        # Resolve either dictionary-style or list-style input
-        if isinstance(precomputed_bot, dict):
-            bot_vals = precomputed_bot.get('portfolio_values', [initial_investment])
-        else:
-            bot_vals = precomputed_bot
-            
+        bot_vals = precomputed_bot.get('portfolio_values', [initial_investment]) if isinstance(precomputed_bot, dict) else precomputed_bot
         if len(bot_vals) >= len(years):
             ax.plot(years, bot_vals[:len(years)], label=f'Bottom {percent}%', color='#9467bd', 
                     marker='v', markersize=4, linewidth=1.5, alpha=0.6)
 
     # 3. Top Cohort (High Contrast)
     if precomputed_top is not None:
-        # Resolve either dictionary-style or list-style input
-        if isinstance(precomputed_top, dict):
-            top_vals = precomputed_top.get('portfolio_values', [initial_investment])
-        else:
-            top_vals = precomputed_top
-
+        top_vals = precomputed_top.get('portfolio_values', [initial_investment]) if isinstance(precomputed_top, dict) else precomputed_top
         if len(top_vals) >= len(years):
             ax.plot(years, top_vals[:len(years)], label=f'Top {percent}%', color='#2ca02c', 
                     marker='^', markersize=5, linewidth=2.0, zorder=4)
@@ -73,22 +84,18 @@ def plot_top_bottom_percent(
 
     # Institutional Chart Formatting
     ax.set_title(f"Factor Efficacy: Top vs. Bottom {percent}% Cohort Spread", 
-                  fontsize=14, fontweight='bold', pad=20)
+                 fontsize=14, fontweight='bold', pad=20)
     ax.set_ylabel("Account Value (USD)", fontsize=11)
     ax.set_xlabel("Year", fontsize=11)
 
-    # Axis and Grid Management
     ax.yaxis.set_major_formatter(mticker.StrMethodFormatter('${x:,.0f}'))
     ax.xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
     
     ax.spines['top'].set_visible(False)
     ax.spines['right'].set_visible(False)
-    ax.grid(True, linestyle='--', alpha=0.4)
-    
-    # Static Reference for Initial Capital
-    ax.axhline(initial_investment, color='#000000', linestyle=':', linewidth=1.2, alpha=0.4)
+    ax.grid(True, linestyle='--', alpha=0.3)
+    ax.axhline(initial_investment, color='#000000', linestyle='-', linewidth=0.8, alpha=0.2)
 
-    ax.legend(loc='upper left', frameon=True, facecolor='white', shadow=True)
-    
+    ax.legend(loc='upper left', frameon=True, facecolor='white', shadow=False, fontsize='small')
     plt.tight_layout()
     return fig

--- a/app/components/results_tab.py
+++ b/app/components/results_tab.py
@@ -2,17 +2,31 @@
 PROJECT: Factor-Lake Portfolio Analysis
 MODULE: app/components/results_tab.py
 PURPOSE: Visualization of results with strict adherence to original metrics and formatting.
-VERSION: 3.6.1
+VERSION: 3.6.2
 """
 
 import streamlit as st
 import pandas as pd
 import numpy as np
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple, Optional
 
 from Visualizations.portfolio_growth_plot import plot_portfolio_growth
 from Visualizations.top_bottom_portfolio_plot import plot_top_bottom_percent
 import src.backtest_engine as backtest_engine
+from app.streamlit_config import FACTOR_METADATA
+
+
+def _build_wealth_series(returns: Optional[List[float]], initial: float) -> Optional[List[float]]:
+    """
+    Converts a yearly return series (in percent) into a cumulative wealth series.
+    """
+    if not returns:
+        return None
+
+    values = [initial]
+    for r in returns:
+        values.append(values[-1] * (1 + (r / 100.0)))
+    return values
 
 def render_results_tab(results: Dict[str, Any], user_settings: Dict[str, Any]) -> None:
     """
@@ -207,7 +221,7 @@ def _render_header_captions(settings: Dict[str, Any]) -> None:
     """
     Renders identifying metadata regarding the specific backtest configuration.
     """
-    selected_factors = st.session_state.get('selected_factor_names') or st.session_state.get('selected_factors', [])
+    selected_factors = st.session_state.get('selected_factor_names')
     saved_dirs = st.session_state.get('factor_directions', {})
     factors_str = ", ".join([f"{f} ({saved_dirs.get(f, 'top')})" for f in selected_factors])
     weighting_str = "Market Cap Weighted" if settings.get('use_market_cap_weight') else "Equal Weighted"
@@ -255,7 +269,11 @@ def _render_cohort_analysis_section(results: Dict[str, Any], user_settings: Dict
             cohort_pct = st.slider("Cohort Percentage", 1, 50, 10)
         
         if st.button("Generate Comparison", type="primary"):
-            factors = st.session_state.get('selected_factor_names') or st.session_state.get('selected_factors', [])
+            selected_factor_names = st.session_state.get('selected_factor_names', [])
+            factors = [
+                FACTOR_METADATA.get(name, {}).get('column', name)
+                for name in selected_factor_names
+            ]
             
             # This now returns lists because of the engine fix above
             res_top, res_bot = backtest_engine.run_cohort_comparison(
@@ -296,7 +314,15 @@ def _render_cohort_analysis_section(results: Dict[str, Any], user_settings: Dict
                 initial_investment=user_settings['initial_aum'],
                 baseline_portfolio_values=results['portfolio_values'],
                 precomputed_top=res_top,
-                precomputed_bot=res_bot
+                precomputed_bot=res_bot,
+                value_returns=_build_wealth_series(
+                    results.get('value_benchmark_returns'),
+                    user_settings['initial_aum']
+                ),
+                growth_returns=_build_wealth_series(
+                    results.get('growth_benchmark_returns'),
+                    user_settings['initial_aum']
+                )
             )
             st.pyplot(fig)
 
@@ -305,19 +331,14 @@ def _render_growth_plot(res: Dict[str, Any], settings: Dict[str, Any]) -> None:
     Visualizes the growth of $1 (or initial AUM) across the portfolio and benchmarks.
     """
     initial = settings.get('initial_aum', 1000000.0)
-    def build_wealth(rets):
-        if not rets: return None
-        v = [initial]
-        for r in rets: v.append(v[-1] * (1 + (r/100.0)))
-        return v
     
     factors = st.session_state.get('selected_factor_names') or st.session_state.get('selected_factors', [])
     fig = plot_portfolio_growth(
         years=res.get('years', []),
         port_vals=res.get('portfolio_values', []),
-        bench_vals=build_wealth(res.get('benchmark_returns')),
-        val_vals=build_wealth(res.get('value_benchmark_returns')),
-        gro_vals=build_wealth(res.get('growth_benchmark_returns')),
+        bench_vals=_build_wealth_series(res.get('benchmark_returns'), initial),
+        val_vals=_build_wealth_series(res.get('value_benchmark_returns'), initial),
+        gro_vals=_build_wealth_series(res.get('growth_benchmark_returns'), initial),
         factor_names=factors
     )
     st.pyplot(fig)


### PR DESCRIPTION
## Summary
This PR fixes a factor-name/DB-column mismatch in cohort analysis, adds growth/value benchmark series to top-vs-bottom visualization, and refreshes README documentation to match the current repository state.

## What changed
- Map selected_factor_names to database column names before cohort comparison runs.
- Add shared wealth-series construction so benchmark series are built consistently from yearly returns.
- Pass growth and value wealth series into the top-vs-bottom cohort plot.
- Update top_bottom_portfolio_plot trajectory handling to support return-like and wealth-like series safely.
- Update README with current project structure, active modules, accurate docs links, and current test/deployment instructions.

## Why
- Prevents cohort analysis from using mismatched factor naming formats.
- Aligns cohort benchmark series handling with the portfolio growth chart conventions.
- Keeps onboarding and contributor guidance accurate and up to date.

## Commits
- 62e2989: factor-name/DB-column mapping and cohort plotting enhancements
- 1f1b244: README modernization and outdated content cleanup