### PR TITLE
Add Supabase upload tool workflow and related documentation updates

### DIFF
--- a/DOCS/DEV_ONBOARDING.md
+++ b/DOCS/DEV_ONBOARDING.md
@@ -2,7 +2,7 @@
 
 This guide walks a new contributor through access, setup, and day-to-day workflow in the order they should do it.
 
-## 1. Wait for access
+## 1. Confirm access to required tools
 
 Before you start, the professor must add you to the required workspaces:
 
@@ -13,15 +13,9 @@ Before you start, the professor must add you to the required workspaces:
 
 Do not start work until all four are available.
 
-## 2. Confirm you can open every tool
+After access is granted, confirm you can open each tool and read team channels/boards.
 
-1. Sign in to the [GitHub Repo](https://github.com/cornell-sysen-5900/Factor-Lake).
-2. Open the [Supabase Project](https://supabase.com/dashboard/project/ozusfgnnzanaxpcfidbm).
-3. Open the [Trello board](https://trello.com/b/fFJ81SzB/quantfinanceproj).
-4. Open [Slack](https://join.slack.com/t/sysen5900/shared_invite/zt-3wraoys1t-yQUj9Hwn7pLrFMISAqG1KQ).
-5. Confirm you can read the team channels and project boards.
-
-## 3. Read the setup docs in order
+## 2. Read the setup docs in order
 
 Use these docs as your first local setup path:
 
@@ -31,7 +25,7 @@ Use these docs as your first local setup path:
 4. Read [Deployment](DEPLOYMENT.md) if you need to publish or verify the app.
 5. Read [Factor Lake User Guide](FACTOR_LAKE_USER_GUIDE.md) to understand the app workflow.
 
-## 4. Set up your local repository
+## 3. Set up your local repository
 
 1. Clone the [Factor-Lake GitHub Repo](https://github.com/cornell-sysen-5900/Factor-Lake).
 2. Create a branch before making changes.
@@ -40,7 +34,7 @@ Use these docs as your first local setup path:
 
 If you need the exact branch-and-commit workflow, follow [Contributing](CONTRIBUTING.md).
 
-## 5. Understand the main tools
+## 4. Understand the main tools
 
 | Tool | What it is for | What to do first |
 |---|---|---|
@@ -52,7 +46,7 @@ If you need the exact branch-and-commit workflow, follow [Contributing](CONTRIBU
 | [ScrumPoker](https://www.scrumpoker-online.org/en/) | Estimation tool | Use it during sprint planning to estimate effort |
 | [Streamlit Cloud](https://share.streamlit.io/) | App hosting | Use it to deploy and verify the Streamlit app |
 
-## 6. Learn the project workflow
+## 5. Learn the project workflow
 
 1. Check the [Trello board](https://trello.com/b/fFJ81SzB/quantfinanceproj) for the story you will work on.
 2. Clarify the story before starting implementation.
@@ -62,14 +56,14 @@ If you need the exact branch-and-commit workflow, follow [Contributing](CONTRIBU
 6. Move the card to `Awaiting PR Approval` while it is under review.
 7. After merge, the card becomes ready for demo in the professor meeting.
 
-## 7. Use Slack correctly
+## 6. Use Slack correctly
 
 1. Use the semester [Slack Workspace](https://join.slack.com/t/sysen5900/shared_invite/zt-3wraoys1t-yQUj9Hwn7pLrFMISAqG1KQ) for questions and coordination.
 2. Post blockers early.
 3. Ask for clarification before editing code or data.
 4. Keep discussions in the semester channel so the whole team stays aligned.
 
-## 8. Know where each deeper guide lives
+## 7. Know where each deeper guide lives
 
 1. [Documentation Contributor Guide](DOCS_CONTRIBUTOR_GUIDE.md) explains how to add or edit docs.
 2. [Contributing](CONTRIBUTING.md) explains the branch-and-commit workflow.
@@ -77,7 +71,7 @@ If you need the exact branch-and-commit workflow, follow [Contributing](CONTRIBU
 4. [Supabase Setup](SUPABASE_SETUP.md) explains how to configure the database connection.
 5. [Streamlit Admin Guide](STREAMLIT_ADMIN_GUIDE.md) explains production app operations.
 
-## 9. Your first-week checklist
+## 8. Your first-week checklist
 
 1. Confirm you can access all required tools.
 2. Read the setup docs.
@@ -85,7 +79,7 @@ If you need the exact branch-and-commit workflow, follow [Contributing](CONTRIBU
 4. Check the Trello Reference list for project links.
 5. Ask one question in Slack if anything is unclear.
 
-## 10. Quick reference
+## 9. Quick reference
 
 | Need | Go here |
 |---|---|
@@ -96,6 +90,6 @@ If you need the exact branch-and-commit workflow, follow [Contributing](CONTRIBU
 | Understand the app workflow | [Factor Lake User Guide](FACTOR_LAKE_USER_GUIDE.md) |
 | Ask questions | [Slack Workspace](https://join.slack.com/t/sysen5900/shared_invite/zt-3wraoys1t-yQUj9Hwn7pLrFMISAqG1KQ) |
 
-## 11. Final rule
+## 10. Final rule
 
 If something is already documented, follow the doc instead of improvising. If something is not clear, ask in [Slack](https://join.slack.com/t/sysen5900/shared_invite/zt-3wraoys1t-yQUj9Hwn7pLrFMISAqG1KQ) and update the relevant guide later if the missing step should be documented.

--- a/DOCS/STREAMLIT_ADMIN_GUIDE.md
+++ b/DOCS/STREAMLIT_ADMIN_GUIDE.md
@@ -27,10 +27,10 @@ Use this guide when you need to keep the production [Factor-Lake Streamlit App](
 
 ## 4. If the app did not redeploy
 
-1. Open the app logs in Streamlit Cloud.
+1. Sign in to Streamlit Cloud with your GitHub account, then open the app logs from the app control panel.
 2. Check for import, dependency, or secret errors.
 3. Confirm `pyproject.toml` includes new dependencies.
-4. Trigger a restart or redeploy if needed.
+4. Trigger a restart or redeploy from the control panel if needed.
 5. Re-test the app after the fix.
 
 ## 5. Manage secrets safely

--- a/DOCS/SUPABASE_MAINTENANCE_GUIDE.md
+++ b/DOCS/SUPABASE_MAINTENANCE_GUIDE.md
@@ -17,64 +17,13 @@ Use this guide when you need to add, clean, change, verify, or troubleshoot data
 3. Keep service role keys out of the app and out of git.
 4. Store production secrets in Streamlit Cloud and local secrets in `.env`.
 
-## 3. Add data to an existing table
+## 3. Add or bulk-upload data
 
-For a small edit:
+Use the dedicated upload workflow in [Supabase Upload Tool](SUPABASE_UPLAOD_TOOL.md).
 
-1. Open the [Factor Lake Supabase Project](https://supabase.com/dashboard/project/ozusfgnnzanaxpcfidbm).
-2. Open Table Editor.
-3. Select the target table.
-4. Insert or edit the row.
-5. Save the change.
-6. Run a quick SQL check to confirm the change looks right.
+Use this maintenance guide for operational checks after upload (schema compatibility, policies, logs, and app validation).
 
-For a bulk import:
-
-1. Prepare a CSV with the exact column headers expected by the table.
-2. Import it into a staging table first when possible.
-3. Check row counts after import.
-4. Check for nulls, duplicates, and bad numeric values.
-5. Promote the cleaned data into the production table only after the checks pass.
-
-## 4. Clean data before you insert it
-
-1. Trim whitespace from IDs and ticker values.
-2. Normalize tickers to a consistent case.
-3. Replace sentinel strings like `N/A` or `--` with nulls.
-4. Make sure `Date` is a valid date.
-5. Derive `Year` consistently from `Date`.
-6. Convert price, return, and factor columns to numeric types.
-7. Remove duplicate business-key rows before promoting data.
-
-Example staging flow:
-
-```sql
-update staging_prices
-set "Ending_Price" = null
-where "Ending_Price" in ('--', 'N/A', '#N/A', 'NULL', 'null', 'nan', '');
-
-delete from staging_prices a
-using staging_prices b
-where a.ctid < b.ctid
-   and a."Ticker-Region" = b."Ticker-Region"
-   and a."Date" = b."Date";
-
-insert into "Full Precision Test" ("Ticker-Region", "Date", "Ending_Price")
-select "Ticker-Region", "Date", "Ending_Price"
-from staging_prices;
-```
-
-## 5. Add a new table
-
-1. Open Table Editor.
-2. Create the new table.
-3. Define columns and the primary key.
-4. Add indexes for the columns you will filter or join on.
-5. Configure RLS if the table needs it.
-6. Load seed data.
-7. Confirm the app does not depend on any missing columns.
-
-## 6. Change which table the app uses
+## 4. Change which table the app uses
 
 1. Open `src/supabase_client.py`.
 2. Find `SupabaseManager.fetch_all_data(table_name='Full Precision Test')`.
@@ -83,7 +32,7 @@ from staging_prices;
 5. Run the app and load data.
 6. Run the integration tests.
 
-## 7. Keep schema compatibility intact
+## 5. Keep schema compatibility intact
 
 1. Preserve `Ticker` or `Ticker-Region` behavior.
 2. Preserve `Year` behavior.
@@ -91,20 +40,20 @@ from staging_prices;
 4. Keep factor columns in sync with `app/streamlit_config.py` and `src/factor_registry.py`.
 5. If you rename a column, update code and retest immediately.
 
-## 8. Maintain the delisting mapping table
+## 6. Maintain the delisting mapping table
 
 1. Keep `last_price_mapping` aligned with the code.
 2. Preserve the source fields `ticker`, `last_date`, and `last_price` unless you are also updating `src/supabase_client.py`.
 3. Confirm the app still merges `Delist_Date` and `Delist_Price` correctly.
 
-## 9. Review policies and logs
+## 7. Review policies and logs
 
 1. Check RLS policies when access changes.
 2. Keep read policies broad enough for the app to work.
 3. Avoid broad write access.
 4. Use Supabase logs when app data loads fail.
 
-## 10. Troubleshoot a broken data load
+## 8. Troubleshoot a broken data load
 
 1. Check the [Factor-Lake Streamlit App](https://cornellfactorlake.streamlit.app/) logs.
 2. Check Supabase logs for rejected queries.
@@ -113,7 +62,7 @@ from staging_prices;
 5. Confirm the required columns still exist.
 6. Run the failing query manually in SQL Editor.
 
-## 11. Make a safe schema change
+## 9. Make a safe schema change
 
 1. Make the change in development or staging first.
 2. Verify row counts and field types.
@@ -122,7 +71,7 @@ from staging_prices;
 5. Run the Streamlit smoke test.
 6. Deploy only after the app still works.
 
-## 12. Delete a table safely
+## 10. Delete a table safely
 
 1. Confirm no app code uses the table.
 2. Confirm no tests depend on the table.
@@ -131,7 +80,7 @@ from staging_prices;
 5. Verify the app and tests still pass.
 6. Delete in production only after that check.
 
-## 13. Verify a Supabase change
+## 11. Verify a Supabase change
 
 1. Run `tests/integration/test_supabase.py`.
 2. Open the Streamlit app.
@@ -140,17 +89,18 @@ from staging_prices;
 5. Confirm the Results tab renders.
 6. Check row counts and numeric ranges.
 
-## 14. What success looks like
+## 12. What success looks like
 
 You are done when the app loads data cleanly, the tests pass, the schema matches the code, and the production app still runs after the change.
 
-## 15. Related guides
+## 13. Related guides
 
 1. [Supabase Setup](SUPABASE_SETUP.md)
-2. [Streamlit Admin Guide](STREAMLIT_ADMIN_GUIDE.md)
-3. [Deployment](DEPLOYMENT.md)
+2. [Supabase Upload Tool](SUPABASE_UPLAOD_TOOL.md)
+3. [Streamlit Admin Guide](STREAMLIT_ADMIN_GUIDE.md)
+4. [Deployment](DEPLOYMENT.md)
 
-## 16. Reference
+## 14. Reference
 
 Use this section when you need the background details that support the workflow above.
 

--- a/DOCS/SUPABASE_MAINTENANCE_GUIDE.md
+++ b/DOCS/SUPABASE_MAINTENANCE_GUIDE.md
@@ -19,7 +19,7 @@ Use this guide when you need to add, clean, change, verify, or troubleshoot data
 
 ## 3. Add or bulk-upload data
 
-Use the dedicated upload workflow in [Supabase Upload Tool](SUPABASE_UPLAOD_TOOL.md).
+Use the dedicated upload workflow in [Supabase Upload Tool](SUPABASE_UPLOAD_TOOL.md).
 
 Use this maintenance guide for operational checks after upload (schema compatibility, policies, logs, and app validation).
 
@@ -96,7 +96,7 @@ You are done when the app loads data cleanly, the tests pass, the schema matches
 ## 13. Related guides
 
 1. [Supabase Setup](SUPABASE_SETUP.md)
-2. [Supabase Upload Tool](SUPABASE_UPLAOD_TOOL.md)
+2. [Supabase Upload Tool](SUPABASE_UPLOAD_TOOL.md)
 3. [Streamlit Admin Guide](STREAMLIT_ADMIN_GUIDE.md)
 4. [Deployment](DEPLOYMENT.md)
 

--- a/DOCS/SUPABASE_SETUP.md
+++ b/DOCS/SUPABASE_SETUP.md
@@ -20,6 +20,13 @@ You can find them here:
 - Click on the word `copy` underneath the project name in the main page and copy the URL.
 - For the key, locate `Project settings` in the side bar -> then click `API Keys.`
 
+### Supabase key types (quick reference)
+
+- **Publishable key**: Intended for client-side or public app contexts with RLS enforcement.
+- **Secret keys**: Server-side keys for trusted backend environments only.
+- **Legacy anon key**: Older public key format used in existing setups; similar purpose to publishable key.
+- **Service role key**: Admin-level server key that bypasses RLS; use only for controlled backend/admin operations.
+
 ## 3. Create your local `.env` file
 
 1. Open the repo root.

--- a/DOCS/SUPABASE_UPLAOD_TOOL.md
+++ b/DOCS/SUPABASE_UPLAOD_TOOL.md
@@ -1,0 +1,137 @@
+# Supabase Upload Tool Workflow
+
+Use this guide when you need to create Supabase table(s) and upload local files with the wrapper script at `tools/run_data_upload_supabase.sh`.
+
+## 1. Know what this tool does
+
+1. Accepts a single file path or a folder path.
+2. Supports `.csv`, `.xlsx`, `.xls`, and `.parquet`.
+3. Creates one table per file.
+4. Defaults table names to file names without extensions.
+5. Enables RLS and adds a public read policy (`anon` and `authenticated`) for each created table.
+6. Uploads data in chunks and validates row counts after upload.
+
+## 2. Confirm prerequisites
+
+1. You have `SUPABASE_URL` and a service role key.
+2. You can run from repo root (`D:/Factor-Lake` on Windows or `/mnt/d/Factor-Lake` in WSL).
+3. Your Python environment includes the required packages for file formats you use:
+   `pandas`, `supabase`, `openpyxl` (Excel), and parquet dependencies.
+
+## 3. Run the one-time Supabase SQL setup
+
+This tool executes DDL via RPC. In Supabase SQL Editor, run:
+
+```sql
+create or replace function public.execute_sql(sql text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  execute sql;
+end;
+$$;
+
+grant execute on function public.execute_sql(text) to service_role;
+```
+
+## 4. Choose input and table naming behavior
+
+1. Single file input:
+   If `TABLE_NAME` is omitted, the table name is the file name without extension.
+2. Folder input:
+   The tool scans supported files and creates one table per file name.
+3. Optional `TABLE_NAME`:
+   Works as an override for single-file uploads only.
+
+## 5. Run the upload command
+
+General command form:
+
+```bash
+bash tools/run_data_upload_supabase.sh \
+  [--supabase-url <SUPABASE_URL>] \
+  [--supabase-service-role-key <SUPABASE_SERVICE_ROLE_KEY>] \
+  <FILE_PATH_OR_FOLDER> \
+  [TABLE_NAME] \
+  [EXTRA_ARGS...]
+```
+
+WSL + Windows Python example:
+
+```bash
+cd /mnt/d/Factor-Lake && \
+PYTHON_BIN="/mnt/c/Users/<you>/anaconda3/envs/<env>/python.exe" \
+bash tools/run_data_upload_supabase.sh \
+  --supabase-url "https://<project-ref>.supabase.co" \
+  --supabase-service-role-key "<service-role-key>" \
+  "C:/Users/<you>/Downloads/data.xlsx"
+```
+
+Folder upload example (common for parquet):
+
+```bash
+cd /mnt/d/Factor-Lake && \
+PYTHON_BIN="/mnt/c/Users/<you>/anaconda3/envs/<env>/python.exe" \
+bash tools/run_data_upload_supabase.sh \
+  --supabase-url "https://<project-ref>.supabase.co" \
+  --supabase-service-role-key "<service-role-key>" \
+  "C:/Users/<you>/Downloads/parquets"
+```
+
+Environment-variable mode:
+
+```bash
+export SUPABASE_URL="https://<project-ref>.supabase.co"
+export SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
+bash tools/run_data_upload_supabase.sh "C:/Users/<you>/Downloads/data.parquet"
+```
+
+## 6. Understand the execution flow
+
+1. Resolve input path(s).
+2. Derive table name(s).
+3. Build and run create-table SQL.
+4. Enable RLS and apply public read policy.
+5. Reload PostgREST schema cache when needed.
+6. Upload batches with retry for schema-cache lag.
+7. Validate upload count and preview rows.
+
+## 7. Troubleshoot common failures
+
+1. `No such file or directory` for script:
+   Run from repo root and call `tools/run_data_upload_supabase.sh`.
+2. `python: command not found`:
+   Set `PYTHON_BIN` explicitly.
+3. `PGRST202` function not found:
+   Run the SQL setup in Section 3.
+4. `PGRST205` table not found in schema cache:
+   Retry; schema reload and retry logic are built in.
+5. Excel dependency error for `openpyxl`:
+   Install or upgrade `openpyxl>=3.1.0` in the same Python environment.
+
+## 8. Verify the upload result
+
+1. Confirm upload batch logs show success.
+2. Confirm row count output is greater than zero.
+3. In Supabase Table Editor, verify the table exists and has rows.
+4. Confirm read access works for `anon` and `authenticated` roles.
+
+## 9. What success looks like
+
+You are done when the table(s) are created, data is uploaded, row counts look correct, and read access works with RLS enabled.
+
+## 10. Related guides
+
+1. [Supabase Setup](SUPABASE_SETUP.md)
+2. [Supabase Maintenance](SUPABASE_MAINTENANCE_GUIDE.md)
+3. [Deployment](DEPLOYMENT.md)
+
+## 11. Reference
+
+1. Wrapper script: `tools/run_data_upload_supabase.sh`
+2. Upload engine: `tools/data_upload_supabase.py`
+3. Supported input extensions: `.csv`, `.xlsx`, `.xls`, `.parquet`
+4. Table naming default: file name without extension

--- a/DOCS/SUPABASE_UPLOAD_TOOL.md
+++ b/DOCS/SUPABASE_UPLOAD_TOOL.md
@@ -15,8 +15,10 @@ Use this guide when you need to create Supabase table(s) and upload local files 
 
 1. You have `SUPABASE_URL` and a service role key.
 2. You can run from repo root (`D:/Factor-Lake` on Windows or `/mnt/d/Factor-Lake` in WSL).
-3. Your Python environment includes the required packages for file formats you use:
-   `pandas`, `supabase`, `openpyxl` (Excel), and parquet dependencies.
+3. Sync the project environment first:
+   `uv sync --group dev`
+4. Upload format dependencies are included in `pyproject.toml` and installed by `uv sync`:
+   `pandas`, `supabase`, `openpyxl` (`.xlsx`), `xlrd` (`.xls`), and `pyarrow` (`.parquet`).
 
 ## 3. Run the one-time Supabase SQL setup
 
@@ -109,8 +111,8 @@ bash tools/run_data_upload_supabase.sh "C:/Users/<you>/Downloads/data.parquet"
    Run the SQL setup in Section 3.
 4. `PGRST205` table not found in schema cache:
    Retry; schema reload and retry logic are built in.
-5. Excel dependency error for `openpyxl`:
-   Install or upgrade `openpyxl>=3.1.0` in the same Python environment.
+5. Excel dependency error for `openpyxl`/`xlrd` or parquet engine error for `pyarrow`:
+   Re-sync dependencies in the same environment: `uv sync --group dev`.
 
 ## 8. Verify the upload result
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,7 +61,7 @@ nav:
     - Contributing: CONTRIBUTING.md
     - Deployment: DEPLOYMENT.md
     - Supabase Setup: SUPABASE_SETUP.md
-    - Supabase Upload Tool: SUPABASE_UPLAOD_TOOL.md
+    - Supabase Upload Tool: SUPABASE_UPLOAD_TOOL.md
     - Supabase Maintenance: SUPABASE_MAINTENANCE_GUIDE.md
     - Streamlit Styling: STREAMLIT_STYLING_GUIDE.md
     - Security Scanning: Bandit & Safety.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
     - Contributing: CONTRIBUTING.md
     - Deployment: DEPLOYMENT.md
     - Supabase Setup: SUPABASE_SETUP.md
+    - Supabase Upload Tool: SUPABASE_UPLAOD_TOOL.md
     - Supabase Maintenance: SUPABASE_MAINTENANCE_GUIDE.md
     - Streamlit Styling: STREAMLIT_STYLING_GUIDE.md
     - Security Scanning: Bandit & Safety.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,14 @@ requires-python = ">=3.10"
 dependencies = [
     "matplotlib>=3.9.0",
     "numpy>=1.23",
+    "openpyxl>=3.1.0",
     "pandas>=2.2.2",
+    "pyarrow>=15.0.0",
     "scipy>=0.8.0",
     "supabase>=2.0.0",
     "streamlit>=1.28.0",
     "plotly>=5.17.0",
+    "xlrd>=2.0.1",
 ]
 
 [dependency-groups]

--- a/tools/data_upload_supabase.py
+++ b/tools/data_upload_supabase.py
@@ -1,6 +1,10 @@
-import importlib
+import argparse
+import datetime as dt
 import os
-from typing import Any, Dict, Optional
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -11,20 +15,37 @@ FILE_PATH = ""  # Example: "data/monthly_prices.csv"
 TABLE_NAME = ""  # Example: "monthly_prices"
 CHUNK_SIZE = 2500
 DATE_COLUMN = "Date"
-MODE = "upload-new-data"  # "new-table-upload" or "upload-new-data"
 CREATE_SQL = ""  # Optional inline SQL for create mode
 CREATE_SQL_FILE = ""  # Optional SQL file path for create mode
 
-MODE_NEW_TABLE_UPLOAD = "new-table-upload"
-MODE_UPLOAD_NEW_DATA = "upload-new-data"
+SUPABASE_URL = ""  # Optional fallback if SUPABASE_URL env var is not set
+SUPABASE_KEY = ""  # Optional fallback if SUPABASE_SERVICE_ROLE_KEY/SUPABASE_KEY env vars are not set
+SUPPORTED_FILE_EXTENSIONS = {".csv", ".xlsx", ".xls", ".parquet"}
+SCHEMA_CACHE_RETRY_ATTEMPTS = 6
+
+SQL_EXECUTOR_SETUP_SQL = """
+create or replace function public.execute_sql(sql text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    execute sql;
+end;
+$$;
+
+grant execute on function public.execute_sql(text) to service_role;
+""".strip()
 
 
 def get_supabase_client() -> Client:
     """Build a Supabase client from environment variables."""
-    url = os.getenv("SUPABASE_URL", "").strip()
+    url = os.getenv("SUPABASE_URL", "").strip() or SUPABASE_URL.strip()
     key = (
         os.getenv("SUPABASE_SERVICE_ROLE_KEY", "").strip()
         or os.getenv("SUPABASE_KEY", "").strip()
+        or SUPABASE_KEY.strip()
     )
 
     if not url or not key:
@@ -36,23 +57,15 @@ def get_supabase_client() -> Client:
     return create_client(url, key)
 
 
-supabase: Client = get_supabase_client()
+_SUPABASE_CLIENT: Optional[Client] = None
 
 
-def _load_psycopg():
-    try:
-        return importlib.import_module("psycopg")
-    except ImportError as exc:
-        raise RuntimeError(
-            "psycopg is required for SQL operations. Install with pip install psycopg[binary]."
-        ) from exc
-
-
-def _get_db_url() -> str:
-    db_url = os.getenv("SUPABASE_DB_URL", "").strip() or os.getenv("DATABASE_URL", "").strip()
-    if not db_url:
-        raise RuntimeError("Missing database URL. Set SUPABASE_DB_URL (or DATABASE_URL).")
-    return db_url
+def get_supabase() -> Client:
+    """Return a cached Supabase client, creating it on first use."""
+    global _SUPABASE_CLIENT
+    if _SUPABASE_CLIENT is None:
+        _SUPABASE_CLIENT = get_supabase_client()
+    return _SUPABASE_CLIENT
 
 
 def _quote_identifier(identifier: str) -> str:
@@ -62,26 +75,53 @@ def _quote_identifier(identifier: str) -> str:
 
 
 def run_sql_execute(sql: str) -> None:
-    """Run a SQL command that does not return rows (for example CREATE TABLE)."""
+    """Run SQL using Supabase RPC; requires a SQL-executor function in the project."""
     if not sql or not sql.strip():
         raise RuntimeError("SQL statement is empty.")
 
-    psycopg = _load_psycopg()
-    with psycopg.connect(_get_db_url()) as conn:
-        with conn.cursor() as cursor:
-            cursor.execute(sql)
-        conn.commit()
+    rpc_attempts = [
+        ("execute_sql", {"sql": sql}),
+        ("execute_sql", {"query": sql}),
+        ("exec_sql", {"sql": sql}),
+        ("run_sql", {"sql": sql}),
+    ]
+    errors: List[str] = []
+
+    for function_name, payload in rpc_attempts:
+        try:
+            get_supabase().rpc(function_name, payload).execute()
+            return
+        except Exception as exc:
+            errors.append(f"{function_name}: {exc}")
+
+    raise RuntimeError(
+        "Could not execute SQL through Supabase RPC. "
+        "Tried execute_sql, exec_sql, and run_sql. "
+        "Create one of these RPC SQL executor functions in Supabase, or pre-create target tables. "
+        f"Create this in Supabase SQL Editor:\n{SQL_EXECUTOR_SETUP_SQL}\n"
+        f"Errors: {' | '.join(errors)}"
+    )
 
 
-def run_sql_fetch(sql: str, params: Optional[tuple] = None) -> pd.DataFrame:
-    """Run a SQL query and return results as a DataFrame."""
-    psycopg = _load_psycopg()
-    with psycopg.connect(_get_db_url()) as conn:
-        with conn.cursor() as cursor:
-            cursor.execute(sql, params or ())
-            rows = cursor.fetchall() if cursor.description else []
-            columns = [desc[0] for desc in cursor.description] if cursor.description else []
-    return pd.DataFrame(rows, columns=columns)
+def run_sql_script(sql_script: str) -> None:
+    """Execute a SQL script one statement at a time via RPC."""
+    statements = [statement.strip() for statement in sql_script.split(";") if statement.strip()]
+    if not statements:
+        raise RuntimeError("SQL script is empty.")
+
+    for statement in statements:
+        run_sql_execute(statement)
+
+
+def request_postgrest_schema_reload() -> None:
+    """Ask PostgREST to reload schema cache so new tables become visible quickly."""
+    run_sql_execute("NOTIFY pgrst, 'reload schema'")
+
+
+def is_schema_cache_table_miss(exc: Exception) -> bool:
+    """Detect PostgREST schema-cache miss errors for newly created tables."""
+    error_text = str(exc).lower()
+    return "pgrst205" in error_text or "schema cache" in error_text
 
 
 def load_create_sql(create_sql: str = "", create_sql_file: str = "") -> str:
@@ -93,22 +133,206 @@ def load_create_sql(create_sql: str = "", create_sql_file: str = "") -> str:
     raise RuntimeError("Provide create SQL via create_sql or create_sql_file.")
 
 
+def resolve_input_files(file_path: str) -> List[Path]:
+    """Resolve file_path into one or more supported input files."""
+    input_path = Path(file_path).expanduser()
+
+    if input_path.is_file():
+        extension = input_path.suffix.lower()
+        if extension not in SUPPORTED_FILE_EXTENSIONS:
+            raise RuntimeError(
+                f"Unsupported file extension '{extension}'. "
+                "Use .csv, .xlsx, .xls, or .parquet files."
+            )
+        return [input_path]
+
+    if input_path.is_dir():
+        files = sorted(
+            path for path in input_path.iterdir() if path.is_file() and path.suffix.lower() in SUPPORTED_FILE_EXTENSIONS
+        )
+        if not files:
+            raise RuntimeError(
+                f"No supported files found in directory: {input_path}. "
+                "Expected .csv, .xlsx, .xls, or .parquet files."
+            )
+        return files
+
+    raise FileNotFoundError(f"Input path does not exist: {input_path}")
+
+
+def normalize_table_name(raw_name: str) -> str:
+    """Convert an arbitrary string into a safe SQL table name."""
+    normalized = re.sub(r"[^a-zA-Z0-9_]+", "_", raw_name.strip().lower()).strip("_")
+    if not normalized:
+        raise RuntimeError(f"Could not derive a valid table name from '{raw_name}'.")
+    if normalized[0].isdigit():
+        normalized = f"t_{normalized}"
+    return normalized
+
+
+def resolve_table_name(base_table_name: str, input_file: Path, multiple_files: bool) -> str:
+    """Determine target table name for a file upload."""
+    base_name = base_table_name.strip()
+    file_stem = normalize_table_name(input_file.stem)
+
+    if multiple_files:
+        return file_stem
+
+    if not base_name:
+        return file_stem
+
+    normalized_base = normalize_table_name(base_name)
+    return normalized_base
+
+
+def load_schema_sample(file_path: str, sample_rows: int = 1000) -> pd.DataFrame:
+    """Load a sample DataFrame used to infer SQL schema for table creation."""
+    extension = os.path.splitext(file_path)[1].lower()
+
+    if extension == ".csv":
+        return pd.read_csv(file_path, nrows=sample_rows)
+
+    if extension in {".xlsx", ".xls"}:
+        return pd.read_excel(file_path, sheet_name=0, nrows=sample_rows)
+
+    if extension == ".parquet":
+        return pd.read_parquet(file_path).head(sample_rows).copy()
+
+    raise RuntimeError(
+        f"Unsupported file extension '{extension}'. Use .csv, .xlsx, .xls, or .parquet files."
+    )
+
+
+def map_dtype_to_postgres(dtype: Any) -> str:
+    """Map inferred dtypes to a robust ingestion-first Postgres column type."""
+    # Spreadsheets frequently contain mixed types within a single column.
+    # Using TEXT prevents insert failures when values vary across rows.
+    return "TEXT"
+
+
+def build_create_table_sql(table_name: str, sample_df: pd.DataFrame) -> str:
+    """Generate a DROP/CREATE TABLE statement from inferred DataFrame schema."""
+    if sample_df.columns.empty:
+        raise RuntimeError("Cannot create table from input with no columns.")
+
+    column_lines = []
+    for column_name in sample_df.columns:
+        column = str(column_name).strip()
+        if not column:
+            raise RuntimeError("Input file contains an empty column name, cannot create SQL schema.")
+        column_type = map_dtype_to_postgres(sample_df[column_name].dtype)
+        column_lines.append(f"{_quote_identifier(column)} {column_type}")
+
+    table_identifier = _quote_identifier(table_name)
+    columns_sql = ",\n    ".join(column_lines)
+    return (
+        f"DROP TABLE IF EXISTS {table_identifier};\n"
+        f"CREATE TABLE {table_identifier} (\n"
+        f"    {columns_sql}\n"
+        ");"
+    )
+
+
+def build_public_read_policy_sql(table_name: str) -> str:
+    """Enable RLS and allow public read access for a table."""
+    table_identifier = _quote_identifier(table_name)
+    policy_identifier = _quote_identifier("public_read_all")
+    return (
+        f"ALTER TABLE {table_identifier} ENABLE ROW LEVEL SECURITY;\n"
+        f"GRANT SELECT ON TABLE {table_identifier} TO anon, authenticated;\n"
+        f"DROP POLICY IF EXISTS {policy_identifier} ON {table_identifier};\n"
+        f"CREATE POLICY {policy_identifier} ON {table_identifier} "
+        "FOR SELECT TO anon, authenticated USING (true);"
+    )
+
+
+def render_create_sql(sql_template: str, table_name: str) -> str:
+    """Render optional placeholders in user-provided SQL templates."""
+    rendered = sql_template
+    rendered = rendered.replace("{table_name}", table_name)
+    rendered = rendered.replace("{table_identifier}", _quote_identifier(table_name))
+    return rendered
+
+
 def clean_record(row_dict: Dict[str, Any]) -> Dict[str, Any]:
     """Ensure values are JSON-safe for Supabase inserts."""
+
+    def _to_json_safe(value: Any) -> Any:
+        if value is None:
+            return None
+
+        # Handle scalar missing values (including pd.NaT / np.nan) before type coercion.
+        try:
+            is_missing = pd.isna(value)
+            if isinstance(is_missing, (bool, np.bool_)) and is_missing:
+                return None
+        except Exception:
+            pass
+
+        if isinstance(value, (pd.Timestamp, dt.datetime, dt.date, dt.time)):
+            return value.isoformat()
+
+        if isinstance(value, pd.Timedelta):
+            return str(value)
+
+        if isinstance(value, np.generic):
+            value = value.item()
+
+        if isinstance(value, np.ndarray):
+            return [_to_json_safe(item) for item in value.tolist()]
+
+        if isinstance(value, (list, tuple, set)):
+            return [_to_json_safe(item) for item in value]
+
+        if isinstance(value, dict):
+            return {str(key): _to_json_safe(item) for key, item in value.items()}
+
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"nat", "nan", "inf", "+inf", "-inf", "infinity", "+infinity", "-infinity"}:
+                return None
+
+        if isinstance(value, float) and np.isinf(value):
+            return None
+
+        return value
+
     cleaned: Dict[str, Any] = {}
     for key, value in row_dict.items():
-        if pd.isna(value) or value is None or (isinstance(value, float) and np.isinf(value)):
-            cleaned[key] = None
-        else:
-            cleaned[key] = value
+        cleaned[key] = _to_json_safe(value)
     return cleaned
+
+
+def iter_data_chunks(file_path: str, chunk_size: int):
+    """Yield DataFrame chunks from supported file types."""
+    extension = os.path.splitext(file_path)[1].lower()
+
+    if extension == ".csv":
+        yield from pd.read_csv(file_path, chunksize=chunk_size)
+        return
+
+    if extension in {".xlsx", ".xls"}:
+        data_frame = pd.read_excel(file_path, sheet_name=0)
+        for start in range(0, len(data_frame), chunk_size):
+            yield data_frame.iloc[start : start + chunk_size].copy()
+        return
+
+    if extension == ".parquet":
+        data_frame = pd.read_parquet(file_path)
+        for start in range(0, len(data_frame), chunk_size):
+            yield data_frame.iloc[start : start + chunk_size].copy()
+        return
+
+    raise RuntimeError(
+        f"Unsupported file extension '{extension}'. Use .csv, .xlsx, .xls, or .parquet files."
+    )
 
 
 def get_last_table_date(table_name: str, date_column: str = DATE_COLUMN) -> Optional[pd.Timestamp]:
     """Return max date currently in table, or None if no rows exist."""
     try:
         response = (
-            supabase.table(table_name)
+            get_supabase().table(table_name)
             .select(date_column)
             .order(date_column, desc=True)
             .limit(1)
@@ -143,7 +367,7 @@ def upload_csv(
     last_date: Optional[pd.Timestamp] = None,
     date_column: str = DATE_COLUMN,
 ) -> None:
-    """Upload CSV rows in batches; if last_date is set, upload only newer rows."""
+    """Upload file rows in batches; if last_date is set, upload only newer rows."""
     if not file_path.strip():
         raise RuntimeError("file_path is required")
     if not table_name.strip():
@@ -151,18 +375,18 @@ def upload_csv(
     if chunk_size <= 0:
         raise RuntimeError("chunk_size must be greater than 0")
     if not os.path.exists(file_path):
-        raise FileNotFoundError(f"CSV file not found: {file_path}")
+        raise FileNotFoundError(f"Data file not found: {file_path}")
 
     uploaded_rows = 0
     skipped_older_rows = 0
     skipped_invalid_date_rows = 0
 
-    reader = pd.read_csv(file_path, chunksize=chunk_size)
+    reader = iter_data_chunks(file_path=file_path, chunk_size=chunk_size)
     for batch_index, chunk in enumerate(reader, start=1):
         if last_date is not None:
             if date_column not in chunk.columns:
                 raise RuntimeError(
-                    f"Date column '{date_column}' not found in CSV. "
+                    f"Date column '{date_column}' not found in file. "
                     f"Available columns: {list(chunk.columns)}"
                 )
 
@@ -179,15 +403,30 @@ def upload_csv(
             continue
 
         cleaned_batch = [clean_record(record) for record in chunk.to_dict(orient="records")]
-        try:
-            supabase.table(table_name).insert(cleaned_batch).execute()
-            uploaded_rows += len(cleaned_batch)
-            print(
-                f"Uploaded batch {batch_index}: {len(cleaned_batch)} rows "
-                f"(running total: {uploaded_rows})"
-            )
-        except Exception as exc:
-            raise RuntimeError(f"Upload failed at batch {batch_index}: {exc}") from exc
+        for attempt in range(1, SCHEMA_CACHE_RETRY_ATTEMPTS + 1):
+            try:
+                get_supabase().table(table_name).insert(cleaned_batch).execute()
+                uploaded_rows += len(cleaned_batch)
+                print(
+                    f"Uploaded batch {batch_index}: {len(cleaned_batch)} rows "
+                    f"(running total: {uploaded_rows})"
+                )
+                break
+            except Exception as exc:
+                if is_schema_cache_table_miss(exc) and attempt < SCHEMA_CACHE_RETRY_ATTEMPTS:
+                    wait_seconds = 0.5 * attempt
+                    print(
+                        f"PostgREST schema cache not ready for table {table_name}; "
+                        f"retrying in {wait_seconds:.1f}s (attempt {attempt}/{SCHEMA_CACHE_RETRY_ATTEMPTS - 1})."
+                    )
+                    try:
+                        request_postgrest_schema_reload()
+                    except Exception:
+                        # Best-effort cache reload; retry still proceeds after delay.
+                        pass
+                    time.sleep(wait_seconds)
+                    continue
+                raise RuntimeError(f"Upload failed at batch {batch_index}: {exc}") from exc
 
     print("Upload process finished.")
     print(f"Total uploaded rows: {uploaded_rows}")
@@ -203,10 +442,23 @@ def create_table_and_upload(
     create_sql_file: str = "",
     chunk_size: int = CHUNK_SIZE,
 ) -> None:
-    """Create table with SQL, then upload entire CSV file."""
-    sql = load_create_sql(create_sql=create_sql, create_sql_file=create_sql_file)
-    run_sql_execute(sql)
+    """Create table with SQL, then upload all rows from the input file."""
+    if create_sql.strip() or create_sql_file.strip():
+        sql_template = load_create_sql(create_sql=create_sql, create_sql_file=create_sql_file)
+        sql = render_create_sql(sql_template, table_name)
+    else:
+        sample_df = load_schema_sample(file_path)
+        sql = build_create_table_sql(table_name=table_name, sample_df=sample_df)
+
+    run_sql_script(sql)
     print(f"Create table SQL executed for table: {table_name}")
+    run_sql_script(build_public_read_policy_sql(table_name))
+    print(f"RLS enabled with public read policy for table: {table_name}")
+    try:
+        request_postgrest_schema_reload()
+    except Exception:
+        # Retry logic in upload handles potential schema-cache lag if this fails.
+        pass
     upload_csv(file_path=file_path, table_name=table_name, chunk_size=chunk_size)
 
 
@@ -240,8 +492,8 @@ def test_table_upload(
     date_column: str = DATE_COLUMN,
     preview_rows: int = 5,
 ) -> Dict[str, Any]:
-    """Validate uploaded table and show latest rows using SQL."""
-    response = supabase.table(table_name).select("*", count="exact").limit(1).execute()
+    """Validate uploaded table and show latest rows using Supabase queries."""
+    response = get_supabase().table(table_name).select("*", count="exact").limit(1).execute()
     row_count = response.count if response.count is not None else 0
     status = "PASS" if row_count > 0 else "FAIL (EMPTY)"
 
@@ -249,18 +501,20 @@ def test_table_upload(
     print(f"Row count: {row_count}")
     print(f"Status: {status}")
 
-    table_ident = _quote_identifier(table_name)
-    date_ident = _quote_identifier(date_column)
-
     try:
-        preview_sql = (
-            f"SELECT * FROM {table_ident} "
-            f"ORDER BY {date_ident} DESC NULLS LAST LIMIT %s"
+        preview_response = (
+            get_supabase()
+            .table(table_name)
+            .select("*")
+            .order(date_column, desc=True)
+            .limit(preview_rows)
+            .execute()
         )
-        preview_df = run_sql_fetch(preview_sql, (preview_rows,))
     except Exception:
-        fallback_sql = f"SELECT * FROM {table_ident} LIMIT %s"
-        preview_df = run_sql_fetch(fallback_sql, (preview_rows,))
+        preview_response = get_supabase().table(table_name).select("*").limit(preview_rows).execute()
+
+    preview_rows_data = preview_response.data if hasattr(preview_response, "data") and preview_response.data else []
+    preview_df = pd.DataFrame(preview_rows_data)
 
     print(f"Last {preview_rows} rows preview:")
     if preview_df.empty:
@@ -277,51 +531,107 @@ def test_table_upload(
 
 
 def run_upload_flow(
-    mode: str,
     file_path: str,
-    table_name: str,
+    table_name: str = "",
     chunk_size: int = CHUNK_SIZE,
     date_column: str = DATE_COLUMN,
     create_sql: str = "",
     create_sql_file: str = "",
 ) -> Dict[str, Any]:
-    """Convenience wrapper: run mode-specific upload then validate table."""
-    if mode == MODE_NEW_TABLE_UPLOAD:
+    """Create and upload one file, or loop a directory and process all supported files."""
+    input_files = resolve_input_files(file_path)
+    multiple_files = len(input_files) > 1 or Path(file_path).expanduser().is_dir()
+    results: Dict[str, Any] = {}
+
+    if multiple_files and table_name.strip():
+        print("Ignoring provided table_name for folder upload; using each file name as table name.")
+
+    for input_file in input_files:
+        target_table = resolve_table_name(table_name, input_file=input_file, multiple_files=multiple_files)
+        print(f"Processing {input_file} -> table {target_table}")
+
         create_table_and_upload(
-            file_path=file_path,
-            table_name=table_name,
+            file_path=str(input_file),
+            table_name=target_table,
             create_sql=create_sql,
             create_sql_file=create_sql_file,
             chunk_size=chunk_size,
         )
-    elif mode == MODE_UPLOAD_NEW_DATA:
-        upload_new_data(
-            file_path=file_path,
-            table_name=table_name,
+
+        results[target_table] = test_table_upload(
+            table_name=target_table,
             date_column=date_column,
-            chunk_size=chunk_size,
-        )
-    else:
-        raise RuntimeError(
-            f"Invalid mode '{mode}'. Use '{MODE_NEW_TABLE_UPLOAD}' or '{MODE_UPLOAD_NEW_DATA}'."
+            preview_rows=5,
         )
 
-    return test_table_upload(table_name=table_name, date_column=date_column, preview_rows=5)
+    return {
+        "processed_files": len(input_files),
+        "tables": list(results.keys()),
+        "results": results,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create table(s) and upload file data into Supabase. Credentials can be provided via environment "
+            "variables or via command-line args for temporary runs."
+        )
+    )
+    parser.add_argument(
+        "--file-path",
+        default=FILE_PATH,
+        help="Path to an input file (.csv, .xlsx, .xls, .parquet) or a folder of supported files",
+    )
+    parser.add_argument(
+        "--table-name",
+        default=TABLE_NAME,
+        help="Optional table name override for a single file upload; folder uploads use each file name",
+    )
+    parser.add_argument("--chunk-size", type=int, default=CHUNK_SIZE, help="Rows per upload batch")
+    parser.add_argument("--date-column", default=DATE_COLUMN, help="Date column used when ordering preview rows")
+    parser.add_argument("--create-sql", default=CREATE_SQL, help="Inline SQL used to create the target table")
+    parser.add_argument("--create-sql-file", default=CREATE_SQL_FILE, help="SQL file path used to create the target table")
+
+    parser.add_argument("--supabase-url", default="", help="Temporary Supabase project URL")
+    parser.add_argument(
+        "--supabase-service-role-key",
+        default="",
+        help="Temporary Supabase service role key",
+    )
+    parser.add_argument("--supabase-key", default="", help="Fallback Supabase API key")
+
+    return parser.parse_args()
+
+
+def apply_runtime_credentials(args: argparse.Namespace) -> None:
+    """Inject temporary credentials into environment variables for this run only."""
+    global _SUPABASE_CLIENT
+
+    if args.supabase_url:
+        os.environ["SUPABASE_URL"] = args.supabase_url
+    if args.supabase_service_role_key:
+        os.environ["SUPABASE_SERVICE_ROLE_KEY"] = args.supabase_service_role_key
+    if args.supabase_key:
+        os.environ["SUPABASE_KEY"] = args.supabase_key
+
+    _SUPABASE_CLIENT = None
 
 
 if __name__ == "__main__":
-    if not FILE_PATH or not TABLE_NAME:
+    args = parse_args()
+    apply_runtime_credentials(args)
+
+    if not args.file_path:
         raise RuntimeError(
-            "Set FILE_PATH and TABLE_NAME in this file, then run again. "
-            "You can also import this module and call run_upload_flow(...)."
+            "Provide --file-path (or set FILE_PATH constant), then run again."
         )
 
     run_upload_flow(
-        mode=MODE,
-        file_path=FILE_PATH,
-        table_name=TABLE_NAME,
-        chunk_size=CHUNK_SIZE,
-        date_column=DATE_COLUMN,
-        create_sql=CREATE_SQL,
-        create_sql_file=CREATE_SQL_FILE,
+        file_path=args.file_path,
+        table_name=args.table_name,
+        chunk_size=args.chunk_size,
+        date_column=args.date_column,
+        create_sql=args.create_sql,
+        create_sql_file=args.create_sql_file,
     )

--- a/tools/run_data_upload_supabase.sh
+++ b/tools/run_data_upload_supabase.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-python}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  tools/run_data_upload_supabase.sh \
+    [--supabase-url <SUPABASE_URL>] \
+    [--supabase-service-role-key <SUPABASE_SERVICE_ROLE_KEY>] \
+    <FILE_PATH> \
+    [TABLE_NAME] \
+    [EXTRA_ARGS...]
+
+Arguments:
+  FILE_PATH                  Input file path (.csv, .xlsx, .xls, .parquet) or folder path
+  TABLE_NAME                 Optional target table name override for single-file uploads
+
+Options:
+  --supabase-url             Optional Supabase project URL override
+  --supabase-service-role-key Optional service role key override
+
+Environment fallback:
+  SUPABASE_URL               Used when --supabase-url is not provided
+  SUPABASE_SERVICE_ROLE_KEY  Used when --supabase-service-role-key is not provided
+
+Notes:
+  Upload flow always creates a new table first.
+  If FILE_PATH is a folder, all supported files in that folder are processed.
+  For folder input, table names are derived from each file name (without extension).
+  For single-file input, table name defaults to the file name unless TABLE_NAME is provided.
+  Pass --create-sql or --create-sql-file in EXTRA_ARGS to override inferred schema.
+
+Examples:
+  tools/run_data_upload_supabase.sh \
+    "C:/Users/you/data.csv" \
+    "my_table" \
+    --supabase-url "https://your-project.supabase.co" \
+    --supabase-service-role-key "your-temp-service-role-key" \
+    --create-sql-file "schema.sql"
+
+  tools/run_data_upload_supabase.sh \
+    "C:/Users/you/parquet_folder"
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+SUPABASE_URL=""
+SUPABASE_SERVICE_ROLE_KEY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --supabase-url)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --supabase-url" >&2
+        usage
+        exit 1
+      fi
+      SUPABASE_URL="$2"
+      shift 2
+      ;;
+    --supabase-service-role-key)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --supabase-service-role-key" >&2
+        usage
+        exit 1
+      fi
+      SUPABASE_SERVICE_ROLE_KEY="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+FILE_PATH="$1"
+TABLE_NAME=""
+shift
+
+if [[ $# -gt 0 && "$1" != --* ]]; then
+  TABLE_NAME="$1"
+  shift
+fi
+
+PYTHON_SCRIPT="$SCRIPT_DIR/data_upload_supabase.py"
+
+if [[ "$PYTHON_BIN" == *.exe ]] && command -v wslpath >/dev/null 2>&1; then
+  # Windows Python invoked from WSL requires Windows-style paths.
+  PYTHON_SCRIPT="$(wslpath -w "$PYTHON_SCRIPT")"
+  if [[ "$FILE_PATH" == /mnt/* ]]; then
+    FILE_PATH="$(wslpath -w "$FILE_PATH")"
+  fi
+fi
+
+CMD=(
+  "$PYTHON_BIN" "$PYTHON_SCRIPT"
+  --file-path "$FILE_PATH"
+)
+
+if [[ -n "$SUPABASE_URL" ]]; then
+  CMD+=(--supabase-url "$SUPABASE_URL")
+fi
+
+if [[ -n "$SUPABASE_SERVICE_ROLE_KEY" ]]; then
+  CMD+=(--supabase-service-role-key "$SUPABASE_SERVICE_ROLE_KEY")
+fi
+
+if [[ -n "$TABLE_NAME" ]]; then
+  CMD+=(--table-name "$TABLE_NAME")
+fi
+
+if [[ $# -gt 0 ]]; then
+  CMD+=("$@")
+fi
+
+"${CMD[@]}"

--- a/uv.lock
+++ b/uv.lock
@@ -677,6 +677,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -696,13 +705,16 @@ dependencies = [
     { name = "matplotlib" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "openpyxl" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "plotly" },
+    { name = "pyarrow" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "streamlit" },
     { name = "supabase" },
+    { name = "xlrd" },
 ]
 
 [package.dev-dependencies]
@@ -723,11 +735,14 @@ docs = [
 requires-dist = [
     { name = "matplotlib", specifier = ">=3.9.0" },
     { name = "numpy", specifier = ">=1.23" },
+    { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.2.2" },
     { name = "plotly", specifier = ">=5.17.0" },
+    { name = "pyarrow", specifier = ">=15.0.0" },
     { name = "scipy", specifier = ">=0.8.0" },
     { name = "streamlit", specifier = ">=1.28.0" },
     { name = "supabase", specifier = ">=2.0.0" },
+    { name = "xlrd", specifier = ">=2.0.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -1878,6 +1893,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/a8/379542d45a14f149444c5c4c4e7714707239ce9cc1de8c2803958889da14/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19710a9ca9992d7174e9c52f643d4272dcd1558c5f7af7f6f8190f633bd651a7", size = 15804253, upload-time = "2026-03-29T13:21:50.753Z" },
     { url = "https://files.pythonhosted.org/packages/a2/c8/f0a45426d6d21e7ea3310a15cf90c43a14d9232c31a837702dba437f3373/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b2aec6af35c113b05695ebb5749a787acd63cafc83086a05771d1e1cd1e555f", size = 16753552, upload-time = "2026-03-29T13:21:54.344Z" },
     { url = "https://files.pythonhosted.org/packages/04/74/f4c001f4714c3ad9ce037e18cf2b9c64871a84951eaa0baf683a9ca9301c/numpy-2.4.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2cf083b324a467e1ab358c105f6cad5ea950f50524668a80c486ff1db24e119", size = 12509075, upload-time = "2026-03-29T13:21:57.644Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]
@@ -3519,6 +3546,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "xlrd"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/5a/377161c2d3538d1990d7af382c79f3b2372e880b65de21b01b1a2b78691e/xlrd-2.0.2.tar.gz", hash = "sha256:08b5e25de58f21ce71dc7db3b3b8106c1fa776f3024c54e45b45b374e89234c9", size = 100167, upload-time = "2025-06-14T08:46:39.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/62/c8d562e7766786ba6587d09c5a8ba9f718ed3fa8af7f4553e8f91c36f302/xlrd-2.0.2-py2.py3-none-any.whl", hash = "sha256:ea762c3d29f4cca48d82df517b6d89fbce4db3107f9d78713e48cd321d5c9aa9", size = 96555, upload-time = "2025-06-14T08:46:37.766Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR adds a dedicated Supabase upload workflow (script + Python engine improvements), documents how to use it, and aligns related guides.

## What changed

### Upload tooling
- Added `tools/run_data_upload_supabase.sh` wrapper for running uploads with optional credential flags.
- Expanded `tools/data_upload_supabase.py` to:
  - support single-file and folder uploads (`.csv`, `.xlsx`, `.xls`, `.parquet`)
  - derive table names from file names by default
  - auto-create tables before upload
  - enable RLS and apply a public read policy for created tables
  - execute SQL via Supabase RPC with clearer setup guidance
  - handle WSL + Windows Python path compatibility
  - sanitize upload payload values (timestamps/NaN/NaT/inf and numpy/pandas types)
  - mitigate PostgREST schema-cache timing with reload + retry behavior

### Dependency coverage (uv)
- Added upload runtime file-format dependencies to `pyproject.toml`:
  - `openpyxl>=3.1.0` for `.xlsx`
  - `xlrd>=2.0.1` for `.xls`
  - `pyarrow>=15.0.0` for `.parquet`
- Regenerated `uv.lock` to pin and sync the new dependencies.

### Documentation
- Added new guide: `DOCS/SUPABASE_UPLOAD_TOOL.md` (corrected filename).
- Updated docs nav in `mkdocs.yml` to point to `SUPABASE_UPLOAD_TOOL.md`.
- Updated links in `DOCS/SUPABASE_MAINTENANCE_GUIDE.md` to the corrected guide path.
- Updated upload guide prerequisites/troubleshooting to use `uv sync --group dev` and document required file-format engines.
- Updated `DOCS/SUPABASE_SETUP.md` with brief Supabase key-type explanations.
- Merged overlapping sections in `DOCS/DEV_ONBOARDING.md` with minimal diff.
- Updated `DOCS/STREAMLIT_ADMIN_GUIDE.md` redeploy step to note GitHub sign-in is required to access the control panel.

## Validation
- Verified edited files are error-free in editor diagnostics.
- `bash -n tools/run_data_upload_supabase.sh` passes.
- `uv lock` resolves successfully after dependency updates.