### PR TITLE
fix(metrics): populate win_rate, win_rate_growth, win_rate_value

### DIFF
--- a/src/performance_metrics.py
+++ b/src/performance_metrics.py
@@ -89,5 +89,8 @@ def compute_comprehensive_metrics(p_ret: np.ndarray, b_ret: np.ndarray, g_ret: n
         'information_ratio': get_ir(p_ret, b_ret),
         'information_ratio_growth': get_ir(p_ret, g_ret),
         'information_ratio_value': get_ir(p_ret, v_ret),
+        'win_rate': float(np.mean(p_ret > b_ret)) if len(p_ret) > 0 else 0.0,
+        'win_rate_growth': float(np.mean(p_ret > g_ret)) if len(p_ret) > 0 else 0.0,
+        'win_rate_value': float(np.mean(p_ret > v_ret)) if len(p_ret) > 0 else 0.0,
         'risk_free_rate_source': "FRED 4 Week T-Bill (Oct 1)"
     }


### PR DESCRIPTION
## Summary

The **Yearly Win Rate** metrics in the Results tab always displayed `0.00%` for all three comparisons (vs R2000, vs Growth, vs Value).

## Root cause

`app/components/results_tab.py` reads three keys from the backtest results dict:

```python
w1.metric("Yearly Win Rate (vs R2000)",  f"{res.get('win_rate', 0):.2%}")
w2.metric("Yearly Win Rate (vs Growth)", f"{res.get('win_rate_growth', 0):.2%}")
w3.metric("Yearly Win Rate (vs Value)",  f"{res.get('win_rate_value', 0):.2%}")
```

But `compute_comprehensive_metrics` in `src/performance_metrics.py` never emitted those keys, so `res.get(..., 0)` always fell back to `0`, rendering as `0.00%`.

## Fix

Add `win_rate`, `win_rate_growth`, and `win_rate_value` to the dict returned by `compute_comprehensive_metrics`, computed as the fraction of years where the portfolio return exceeded each benchmark. Includes an empty-period guard.

```python
'win_rate':        float(np.mean(p_ret > b_ret)) if len(p_ret) > 0 else 0.0,
'win_rate_growth': float(np.mean(p_ret > g_ret)) if len(p_ret) > 0 else 0.0,
'win_rate_value':  float(np.mean(p_ret > v_ret)) if len(p_ret) > 0 else 0.0,
```

Values are fractions in `[0, 1]`, matching the existing `:.2%` format string in `results_tab.py`. No UI changes required.

## Verification

Ad-hoc test with 4 synthetic yearly return periods produced the expected fractions:

| Metric | Computed | Expected |
| --- | --- | --- |
| `win_rate` (vs R2000) | 0.5 | 0.5 |
| `win_rate_growth`     | 0.5 | 0.5 |
| `win_rate_value`      | 1.0 | 1.0 |

Empty-input edge case returns `0.0` for all three without raising.

## Files changed

- `src/performance_metrics.py` (+3 lines)
